### PR TITLE
add port setting

### DIFF
--- a/services/sherlock/main.py
+++ b/services/sherlock/main.py
@@ -50,6 +50,7 @@ def lookup(names):
         settings = yaml.safe_load(f)
         connection = pymysql.connect(
             host=settings['database']['host'],
+            port=settings['database']['port'],
             user=settings['database']['username'],
             password=settings['database']['password'],
             db=settings['database']['db'],


### PR DESCRIPTION
Add a port setting so that sherlock service can use either 3306 or 9001 as required.

Related to https://github.com/lsst-uk/lasair-deploy/issues/111