### PR TITLE
Feature/handle sigterm

### DIFF
--- a/pipeline/filter/filter.py
+++ b/pipeline/filter/filter.py
@@ -93,7 +93,7 @@ def main(args):
             '--topic_in',       topic_in
             ]
     print(' '.join(args))
-    process = Popen(args, stdout=PIPE, stderr=PIPE)
+    process = Popen(args)
     process.wait()
     rc = process.returncode
 

--- a/pipeline/filter/filter.py
+++ b/pipeline/filter/filter.py
@@ -86,11 +86,11 @@ def main(args):
     args = [
             'python3',
             'consume_alerts.py',
-            '--maxalert %d ' % maxalert,
-            '--nprocess %d ' % nprocess,
-            '--group %s '    % group_id,
-            '--host %s '     % settings.KAFKA_SERVER,
-            '--topic_in ' + topic_in
+            '--maxalert','%d' % maxalert,
+            '--nprocess','%d' % nprocess,
+            '--group','%s'    % group_id,
+            '--host','%s'     % settings.KAFKA_SERVER,
+            '--topic_in',       topic_in
             ]
     print(' '.join(args))
     process = Popen(args, stdout=PIPE, stderr=PIPE)

--- a/pipeline/filter/filter.py
+++ b/pipeline/filter/filter.py
@@ -82,7 +82,7 @@ def main(args):
     print("Topic is %s" % topic_in)
     t = time.time()
     
-    # use subprocess here rather than os.system because we want signals to propagate
+    # use subprocess here rather than os.system because we want child process to be in same PID group
     args = [
             'python3',
             'consume_alerts.py',

--- a/pipeline/filter/filter.py
+++ b/pipeline/filter/filter.py
@@ -33,6 +33,12 @@ import run_active_queries
 from check_alerts_watchlists import get_watchlist_hits, insert_watchlist_hits
 from check_alerts_areas import get_area_hits, insert_area_hits
 from counts import since_midnight, grafana_today
+import signal
+
+def sigterm_handler(signum, frame):
+    pass
+
+signal.signal(signal.SIGTERM, sigterm_handler)
 
 def main(args):
     if args['--topic_in']:

--- a/pipeline/filter/filter_runner.py
+++ b/pipeline/filter/filter_runner.py
@@ -79,7 +79,11 @@ while 1:
         # else just go ahead immediately
         elif rc == 0:
             log.write("END waiting %d seconds ...\n\n" % settings.WAIT_TIME)
-            time.sleep(settings.WAIT_TIME)
+            for i in range(settings.WAIT_TIME):
+                if sigterm_raised:
+                    log.write("Caught SIGTERM, exiting.\n")
+                    sys.exit(0)
+                time.sleep(1)
         else:   # rc < 0
             log.write("STOP on error!")
             sys.exit(1)

--- a/pipeline/filter/filter_runner.py
+++ b/pipeline/filter/filter_runner.py
@@ -22,16 +22,16 @@ def now():
     return datetime.utcnow().strftime("%Y/%m/%dT%H:%M:%S")
 
 # if there is an argument, use it on the filter instances
+arg = None
+if len(sys.argv) > 1: arg = sys.argv[1]
+
+# where the log files go
+if arg:
+    log = open('/home/ubuntu/logs/' + arg + '.log', 'a')
+else:
+    log = open('/home/ubuntu/logs/ingest.log', 'a')
+
 while 1:
-    arg = None
-    if len(sys.argv) > 1: arg = sys.argv[1]
-
-    # where the log files go
-    if arg:
-        log = open('/home/ubuntu/logs/' + arg + '.log', 'a')
-    else:
-        log = open('/home/ubuntu/logs/ingest.log', 'a')
-
     if sigterm_raised:
         log.write("Caught SIGTERM, exiting.\n")
         sys.exit(0)
@@ -84,7 +84,6 @@ while 1:
             log.write("STOP on error!")
             sys.exit(1)
 
-        log.close()
     else:
         # wait until the lockfile reappears
         rtxt = 'Waiting for lockfile ' + now()

--- a/pipeline/filter/filter_runner.py
+++ b/pipeline/filter/filter_runner.py
@@ -33,7 +33,7 @@ while 1:
         log = open('/home/ubuntu/logs/ingest.log', 'a')
 
     if sigterm_raised:
-        log.write("Caught SIGTERM, exiting.")
+        log.write("Caught SIGTERM, exiting.\n")
         sys.exit(0)
 
     if os.path.isfile(settings.LOCKFILE):
@@ -50,6 +50,7 @@ while 1:
             # if the worher uses 'print', there will be at least the newline
             rtxt = rbin.decode('utf-8').rstrip()
             log.write(rtxt + '\n')
+            log.flush()
             print(rtxt)
 
             # scream to the humans if ERROR
@@ -64,6 +65,7 @@ while 1:
             # if the worher uses 'print', there will be at least the newline
             rtxt = 'stderr:' + rbin.decode('utf-8').rstrip()
             log.write(rtxt + '\n')
+            log.flush()
             print(rtxt)
 
 
@@ -88,5 +90,6 @@ while 1:
         rtxt = 'Waiting for lockfile ' + now()
         print(rtxt)
         log.write(rtxt + '\n')
+        log.flush()
         time.sleep(settings.WAIT_TIME)
 

--- a/pipeline/filter/filter_runner.py
+++ b/pipeline/filter/filter_runner.py
@@ -34,6 +34,7 @@ else:
 while 1:
     if sigterm_raised:
         log.write("Caught SIGTERM, exiting.\n")
+        log.flush()
         sys.exit(0)
 
     if os.path.isfile(settings.LOCKFILE):
@@ -82,10 +83,12 @@ while 1:
             for i in range(settings.WAIT_TIME):
                 if sigterm_raised:
                     log.write("Caught SIGTERM, exiting.\n")
+                    log.flush()
                     sys.exit(0)
                 time.sleep(1)
         else:   # rc < 0
             log.write("STOP on error!")
+            log.flush()
             sys.exit(1)
 
     else:

--- a/pipeline/filter/filter_runner.py
+++ b/pipeline/filter/filter_runner.py
@@ -6,6 +6,16 @@ import settings
 from datetime import datetime
 from subprocess import Popen, PIPE
 from src import slack_webhook
+import signal
+
+# If we catch a SIGTERM, set a flag
+sigterm_raised = False
+
+def sigterm_handler(signum, frame):
+    global sigterm_raised
+    sigterm_raised = True
+
+signal.signal(signal.SIGTERM, sigterm_handler)
 
 def now():
     # current UTC as string
@@ -21,6 +31,10 @@ while 1:
         log = open('/home/ubuntu/logs/' + arg + '.log', 'a')
     else:
         log = open('/home/ubuntu/logs/ingest.log', 'a')
+
+    if sigterm_raised:
+        log.write("Caught SIGTERM, exiting.")
+        sys.exit(0)
 
     if os.path.isfile(settings.LOCKFILE):
         args = ['python3', 'filter.py']

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -38,6 +38,7 @@ sigterm_raised = False
 
 def sigterm_handler(signum, frame):
     global sigterm_raised
+    sigterm_raised = True
     print("Caught SIGTERM")
 
 signal.signal(signal.SIGTERM, sigterm_handler)
@@ -227,9 +228,10 @@ def run(runarg, return_dict):
     startt = time.time()
     while nalert < maxalert:
         if sigterm_raised:
+            # clean shutdown - this should stop the consumer and commit offsets
             print("Stopping ingest")
             sys.stdout.flush()
-            alertConsumer.close()
+            streamReader.consumer.close()
             break
 
         t = time.time()

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -32,6 +32,12 @@ from gkhtm import _gkhtm as htmCircle
 from cassandra.cluster import Cluster
 from gkdbutils.ingesters.cassandra import executeLoad
 import os, time, json, zlib
+import signal
+
+def sigterm_handler(signum, frame):
+    print("Ignoring SIGTERM")
+
+signal.signal(signal.SIGTERM, sigterm_handler)
 
 def now():
     # current UTC as string

--- a/pipeline/ingest/ingest_runner.py
+++ b/pipeline/ingest/ingest_runner.py
@@ -70,7 +70,11 @@ while 1:
     
         if rc == 0:  # no more to get
             log.write("END waiting %d seconds ...\n\n" % settings.WAIT_TIME)
-            time.sleep(settings.WAIT_TIME)
+            for i in range(settings.WAIT_TIME):
+                if sigterm_raised:
+                    log.write("Caught SIGTERM, exiting.\n")
+                    sys.exit(0)
+                time.sleep(1)
         else:
             log.write("END getting more ...\n\n")
         log.close()

--- a/pipeline/ingest/ingest_runner.py
+++ b/pipeline/ingest/ingest_runner.py
@@ -32,7 +32,7 @@ while 1:
     topic  = 'ztf_' + date + '_programid1'
     log = open('/home/ubuntu/logs/' + topic + '.log', 'a')
     if sigterm_raised:
-        log.write("Caught SIGTERM, exiting.")
+        log.write("Caught SIGTERM, exiting.\n")
         sys.exit(0)
 
     if os.path.isfile(settings.LOCKFILE):
@@ -48,6 +48,7 @@ while 1:
             # if the worher uses 'print', there will be at least the newline
             rtxt = rbin.decode('utf-8').rstrip()
             log.write(rtxt + '\n')
+            log.flush()
 
             # scream to the humans if ERROR
             if rtxt.startswith('ERROR'):
@@ -61,6 +62,7 @@ while 1:
             # if the worher uses 'print', there will be at least the newline
             rtxt = 'stderr:' + rbin.decode('utf-8').rstrip()
             log.write(rtxt + '\n')
+            log.flush()
             print(rtxt)
 
         process.wait()
@@ -77,4 +79,5 @@ while 1:
         rtxt = 'Waiting for lockfile ' + now()
         print(rtxt)
         log.write(rtxt + '\n')
+        log.flush()
         time.sleep(settings.WAIT_TIME)


### PR DESCRIPTION
Modifying the ingest and filter pipeline so that they intercept a SIGTERM and do a graceful shutdown. This is preliminary to working on https://github.com/lsst-uk/lasair-deploy/issues/87

Sending a SIGTERM to the parent PID only (i.e. ingest_runner/filter_runner) will result in the current batch running to completion (i.e. maxalerts or end of the stream); sending a SIGTERM to the whole process group (as when stopping a systemd service) will immediately stop polling for new alerts, but will still commit offsets and process the alerts already retrieved before exiting (hopefully this should take only a few seconds).

This appears to make the lockfile system redundant, but it is retained for now for backwards compatibility.

Notes:
1. We are still auto-committing the offsets for alerts before a stage has fully processed them. It would be safer to do manual offset commits.
2. Setting up and tearing down the Kafka consumer for every alert batch is inefficient. We are currently fudging this by using large batches, but we should fix it at some point.
