### PR TITLE
No kafka commit until batch is in main database

### DIFF
--- a/pipeline/filter/consume_alerts.py
+++ b/pipeline/filter/consume_alerts.py
@@ -9,7 +9,6 @@ import settings
 
 from multiprocessing import Process, Manager
 from features_ZTF import insert_query
-import confluent_kafka
 import argparse, time, json
 import signal
 
@@ -52,32 +51,13 @@ sherlock_attributes = [
     "summary",
 ]
 
-def parse_args():
-    """parse_args.
-    """
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--host', type=str,
-                        help='Hostname or IP of Kafka host to connect to.')
-
-    parser.add_argument('--topic_in', type=str,
-                        help='Name of Kafka topic to listen to.')
-
-    parser.add_argument('--group', type=str,
-                        help='Globally unique name of the consumer group. '
-                        'Consumers in the same group will share messages '
-                        '(i.e., only one consumer will receive a message, '
-                        'as in a queue). Default is value of $HOSTNAME.')
-
-    parser.add_argument('--maxalert', type=int,
-                        help='Max alerts to be fetched per process')
-
-    parser.add_argument('--nprocess', type=int,
-                        help='Number of process to use')
-
-    args = parser.parse_args()
-    return args
-
 def execute_query(query, msl):
+    """ execute_query: run a query and close it, and compalin to slack if failure
+
+    Args:
+        query:
+        msl:
+    """
     try:
         cursor = msl.cursor(buffered=True)
         cursor.execute(query)
@@ -90,7 +70,7 @@ def execute_query(query, msl):
         raise
 
 def alert_filter(alert, msl):
-    """alert_filter.
+    """alert_filter: handle a single alert
 
     Args:
         alert:
@@ -132,36 +112,24 @@ def alert_filter(alert, msl):
                 execute_query(query, msl)
     return {'ss':iq_dict['ss'], 'nalert':1}
 
-def run(runarg, return_dict):
-    """run.
+def kafka_consume(consumer, maxalert):
+    """ kafka_consume: consume maxalert alerts from the consumer
+        Args:
+            consumer: confluent_kafka Consumer
+            maxalert: how many to consume
     """
-    processID = runarg['processID']
+
     # Configure database connection
     try:
         msl = db_connect.local()
     except Exception as e:
         print('ERROR cannot connect to local database', e)
         sys.stdout.flush()
-        return
-
-    # Start consumer and print alert stream
-    try:
-        consumer = confluent_kafka.Consumer(**runarg['conf'])
-        consumer.subscribe([runarg['args'].topic_in])
-    except Exception as e:
-        print('ERROR cannot connect to kafka', e)
-        sys.stdout.flush()
-        return
-
-    # Number of alerts in the batch
-    if runarg['args'].maxalert:
-        maxalert = runarg['args'].maxalert
-    else:
-        maxalert = 50000
+        return -1    # error return
 
     nalert_in = nalert_out = nalert_ss = 0
     startt = time.time()
-    commit = True
+
     while nalert_in < maxalert:
         if sigterm_raised:
             # clean shutdown - stop the consumer and commit offsets
@@ -177,87 +145,25 @@ def run(runarg, return_dict):
             continue
         if msg.value() is None:
             continue
-        else:
-            # Apply filter to each alert
-            alert = json.loads(msg.value())
-            nalert_in += 1
-            try:
-                d = alert_filter(alert, msl)
-                nalert_out += d['nalert']
-                nalert_ss  += d['ss']
-            except:
-                commit = False
-                break
-            if nalert_in%1000 == 0:
-                print('process %d nalert_in %d nalert_out  %d time %.1f' % 
-                    (processID, nalert_in, nalert_out, time.time()-startt))
-                sys.stdout.flush()
-                # refresh the database every 1000 alerts
-                # make sure everything is committed
-                msl.close()
-                msl = db_connect.local()
+        # Apply filter to each alert
+        alert = json.loads(msg.value())
+        nalert_in += 1
+        print(alert['objectId'])
+        try:
+            d = alert_filter(alert, msl)
+            nalert_out += d['nalert']
+            nalert_ss  += d['ss']
+        except:
+            break
 
-    if commit:
-        consumer.commit()
-    else:
-        rtxt = 'ERROR: filter/consume_alerts: Batch not committed'
-        print(rtxt)
-        slack_webhook.send(settings.SLACK_URL, rtxt)
-
-    consumer.close()
-    return_dict[processID] = {
-            'nalert_in':nalert_in, 
-            'nalert_out': nalert_out, 
-            'nalert_ss':nalert_ss 
-            }
-
-
-def main():
-    """main.
-    """
-    args = parse_args()
-
-    # Configure consumer connection to Kafka broker
-    conf = {
-        'bootstrap.servers': '%s' % args.host,
-        'enable.auto.commit': False,
-        'default.topic.config': {
-             'auto.offset.reset': 'smallest'
-        }}
-    if args.group: conf['group.id'] = args.group
-    else:          conf['group.id'] = 'LASAIR'
-    print('Configuration = %s' % str(conf))
-
-    # How many processs
-    if args.nprocess: nprocess = args.nprocess
-    else:             nprocess = 1
-    print('Processes = %d' % nprocess)
-    sys.stdout.flush()
-
-    runargs = []
-    process_list = []
-    manager = Manager()
-    return_dict = manager.dict()
-    t = time.time()
-    for t in range(nprocess):
-        runarg = {
-            'processID':t,
-            'args':args,
-            'conf':conf,
-        }
-        p = Process(target=run, args=(runarg, return_dict))
-        process_list.append(p)
-        p.start()
-
-    for p in process_list:
-        p.join()
-
-    r = return_dict.values()
-    nalert_in = nalert_out = nalert_ss = 0
-    for t in range(nprocess):
-        nalert_in  += r[t]['nalert_in']
-        nalert_out += r[t]['nalert_out']
-        nalert_ss  += r[t]['nalert_ss']
+        if nalert_in%1000 == 0:
+            print('process %d nalert_in %d nalert_out  %d time %.1f' % 
+                (processID, nalert_in, nalert_out, time.time()-startt))
+            sys.stdout.flush()
+            # refresh the database every 1000 alerts
+            # make sure everything is committed
+            msl.close()
+            msl = db_connect.local()
 
     print('INGEST finished %d in, %d out, %d solar system' % (nalert_in, nalert_out, nalert_ss))
     sys.stdout.flush()
@@ -270,18 +176,5 @@ def main():
         'today_filter_ss':nalert_ss
         }, nid)
 
-    if nalert_in > 0: return 1
-    else:             return 0
-
-if __name__ == '__main__':
-    try:
-        rc = main()
-        sys.exit(rc)
-    except Exception as e:
-        rtxt = "ERROR in filter/consume_alerts:"
-        rtxt += str(e)
-        slack_webhook.send(settings.SLACK_URL, rtxt)
-        print(rtxt)
-        sys.stdout.flush()
-        sys.exit(0)
-
+    if nalert_in > 0: return 1   # got some alerts
+    else:             return 0   # got no alerts

--- a/pipeline/filter/filter.py
+++ b/pipeline/filter/filter.py
@@ -78,12 +78,12 @@ def main(args):
     t = time.time()
     
     conf = {
-        'bootstrap.servers': '%s' % settings.KAFKA_SERVER,
-        'enable.auto.commit': False,   # require explicit commit!
-        'group.id':           group_id,
-        'default.topic.config': {
-             'auto.offset.reset': 'smallest'
-        }}
+        'bootstrap.servers'   : '%s' % settings.KAFKA_SERVER,
+        'enable.auto.commit'  : False,   # require explicit commit!
+        'group.id'            : group_id,
+        'max.poll.interval.ms': 20*60*1000,  # 20 minute timeout in case queries take time
+        'default.topic.config': { 'auto.offset.reset': 'smallest' }
+    }
     print(conf, topic_in)
     try:
         consumer = confluent_kafka.Consumer(conf)

--- a/pipeline/filter/filter.py
+++ b/pipeline/filter/filter.py
@@ -8,13 +8,11 @@ Filter code for Lasair.
     send data to main db with mysql --host
 
 Usage:
-    filter.py [--nprocess=NPROCESS]
-              [--maxalert=MAX]
+    filter.py [--maxalert=MAX]
               [--group_id=GID]
               [--topic_in=TIN]
 
 Options:
-    --nprocess=NP      Number of processes to use [default:1]
     --maxalert=MAX     Number of alerts to process, default is from settings.
     --group_id=GID     Group ID for kafka, default is from settings
     --topic_in=TIN     Kafka topic to use, default is from settings
@@ -24,6 +22,7 @@ import os,sys
 sys.path.append('../../common')
 import settings
 import time, tempfile
+import confluent_kafka
 from docopt import docopt
 from socket import gethostname
 from datetime import datetime
@@ -33,6 +32,7 @@ import run_active_queries
 from check_alerts_watchlists import get_watchlist_hits, insert_watchlist_hits
 from check_alerts_areas import get_area_hits, insert_area_hits
 from counts import since_midnight, grafana_today
+from consume_alerts import kafka_consume
 from subprocess import Popen, PIPE
 import signal
 
@@ -47,11 +47,6 @@ def main(args):
     else:
         topic_in  = 'ztf_sherlock'
 
-    if args['--nprocess']:
-        nprocess = int(args['--nprocess'])
-    else:
-        nprocess = 2
-
     if args['--group_id']:
         group_id = args['--group_id']
     else:
@@ -62,7 +57,7 @@ def main(args):
     else:
         maxalert = settings.KAFKA_MAXALERTS
 
-    print('Topic_in=%s, group_id=%s, nprocess=%d, maxalert=%d' % (topic_in, group_id, nprocess, maxalert))
+    print('Topic_in=%s, group_id=%s, maxalert=%d' % (topic_in, group_id, maxalert))
 
     print('------------------')
     ##### clear out the local database
@@ -82,24 +77,27 @@ def main(args):
     print("Topic is %s" % topic_in)
     t = time.time()
     
-    # use subprocess here rather than os.system because we want child process to be in same PID group
-    args = [
-            'python3',
-            'consume_alerts.py',
-            '--maxalert','%d' % maxalert,
-            '--nprocess','%d' % nprocess,
-            '--group','%s'    % group_id,
-            '--host','%s'     % settings.KAFKA_SERVER,
-            '--topic_in',       topic_in
-            ]
-    print(' '.join(args))
-    process = Popen(args)
-    process.wait()
-    rc = process.returncode
+    conf = {
+        'bootstrap.servers': '%s' % settings.KAFKA_SERVER,
+        'enable.auto.commit': False,   # require explicit commit!
+        'group.id':           group_id,
+        'default.topic.config': {
+             'auto.offset.reset': 'smallest'
+        }}
+    print(conf, topic_in)
+    try:
+        consumer = confluent_kafka.Consumer(conf)
+        consumer.subscribe([topic_in])
+    except Exception as e:
+        print('ERROR cannot connect to kafka', e)
+        sys.stdout.flush()
+        return
+
+    rc = kafka_consume(consumer, maxalert)
 
     # rc is the return code from ingestion, number of alerts received
     if rc < 0:
-        rtxt = "ERROR in filter/filter: consume_alerts failed"
+        rtxt = "ERROR in filter/filter: consume_kafka failed"
         slack_webhook.send(settings.SLACK_URL, rtxt)
         print(rtxt)
         sys.stdout.flush()
@@ -233,6 +231,8 @@ def main(args):
     ##### send CSV file to central database
     t = time.time()
 
+    #### if one of the tables doesn't go through, we run this batch again
+    commit = True
     for table in tablelist:
         sql  = "LOAD DATA LOCAL INFILE '/data/mysql/%s.txt' " % table
         sql += "REPLACE INTO TABLE %s FIELDS TERMINATED BY ',' " % table
@@ -250,10 +250,21 @@ def main(args):
             slack_webhook.send(settings.SLACK_URL, rtxt)
             print(rtxt)
             sys.stdout.flush()
+            commit = False
         else:
             print(table, 'ingested to main db')
 
     print('Transfer to main database %.1f seconds' % (time.time() - t))
+    if commit:
+        consumer.commit()
+        consumer.close()
+        print('Kafka committed for this batch')
+    else:
+        print('Waiting 10 minutes')
+        consumer.close()
+        time.sleep(600)
+        sys.exit(1)
+
     sys.stdout.flush()
     
     ms = manage_status(settings.SYSTEM_STATUS)

--- a/pipeline/filter/filter_runner.py
+++ b/pipeline/filter/filter_runner.py
@@ -21,15 +21,8 @@ def now():
     # current UTC as string
     return datetime.utcnow().strftime("%Y/%m/%dT%H:%M:%S")
 
-# if there is an argument, use it on the filter instances
-arg = None
-if len(sys.argv) > 1: arg = sys.argv[1]
-
 # where the log files go
-if arg:
-    log = open('/home/ubuntu/logs/' + arg + '.log', 'a')
-else:
-    log = open('/home/ubuntu/logs/ingest.log', 'a')
+log = open('/home/ubuntu/logs/ingest.log', 'a')
 
 while 1:
     if sigterm_raised:
@@ -38,8 +31,8 @@ while 1:
         sys.exit(0)
 
     if os.path.isfile(settings.LOCKFILE):
-        args = ['python3', 'filter.py']
-        if arg: args.append(arg)
+        # args on the command line passed to filter.py
+        args = ['python3', 'filter.py'] + sys.argv[1:]
         print('------', now())
         process = Popen(args, stdout=PIPE, stderr=PIPE)
 


### PR DESCRIPTION
Committing the kafka consumer is delayed until all the local database is transferred and ingested by the main database. If not, the slack squawks and it wait ten minutes. The same batch is processed over and over until the database accepts the results. A side-effect of this is that the multi-processing option has been removed. Also, complexity is reduced as the alert consumption code is now called as a function rather than a subprocess.