### PR TITLE
Hotfix/querybug

### DIFF
--- a/webserver/lasair/query_builder.py
+++ b/webserver/lasair/query_builder.py
@@ -211,8 +211,6 @@ def build_query(select_expression, from_expression, where_condition):
         else:
             if len(where_condition.strip()) > 0:
                 where_clauses.append(where_condition)
-    else:
-        where_clauses = []
 
     # Now we can build the real SQL
     sql = 'SELECT /*+ MAX_EXECUTION_TIME(%d) */ ' % max_execution_time


### PR DESCRIPTION
While fiddling with the queries this morning, I found that the wrong query is generated if there are tables to be joined but no WHERE clause. I have checked that all the queries still pass their checks using the [query checker](https://github.com/lsst-uk/lasair4/blob/main/utility/check_query_syntax.py)