### PR TITLE
topic_refresh no longer runs query

### DIFF
--- a/webserver/lasair/apps/filter_query/utils.py
+++ b/webserver/lasair/apps/filter_query/utils.py
@@ -4,8 +4,8 @@ from lasair.apps.db_schema.utils import get_schema, get_schema_dict, get_schema_
 from lasair.utils import datetime_converter
 import settings
 import os
-import datetime
-
+from datetime import datetime
+from confluent_kafka import admin
 
 def add_filter_query_metadata(
         filter_queries,
@@ -168,22 +168,22 @@ def topic_refresh(real_sql, topic, limit=10):
     ```
     """
     message = ''
-    msl = db_connect.readonly()
-    cursor = msl.cursor(buffered=True, dictionary=True)
-    query = real_sql + ' LIMIT %d' % limit
+#    msl = db_connect.readonly()
+#    cursor = msl.cursor(buffered=True, dictionary=True)
+#    query = real_sql + ' LIMIT %d' % limit
 
-    try:
-        cursor.execute(query)
-    except Exception as e:
-        message += 'Your query:<br/><b>' + query + '</b><br/>returned the error<br/><i>' + str(e) + '</i><br/>'
-        return message
+#    try:
+#        cursor.execute(query)
+#    except Exception as e:
+#        message += 'Your query:<br/><b>' + query + '</b><br/>returned the error<br/><i>' + str(e) + '</i><br/>'
+#        return message
 
-    recent = []
-    for record in cursor:
-        recorddict = dict(record)
-        now_number = datetime.utcnow()
-        recorddict['UTC'] = now_number.strftime("%Y-%m-%d %H:%M:%S")
-        recent.append(recorddict)
+#    recent = []
+#    for record in cursor:
+#        recorddict = dict(record)
+#        now_number = datetime.utcnow()
+#        recorddict['UTC'] = now_number.strftime("%Y-%m-%d %H:%M:%S")
+#        recent.append(recorddict)
 
     conf = {
         'bootstrap.servers': settings.PUBLIC_KAFKA_SERVER,
@@ -206,15 +206,15 @@ def topic_refresh(real_sql, topic, limit=10):
         message += str(e) + '<br/>'
 
     # pushing in new messages will remake the topic
-    try:
-        p = Producer(conf)
-        for out in recent:
-            jsonout = json.dumps(out, default=datetime_converter)
-            p.produce(topic, value=jsonout)
-        p.flush(10.0)   # 10 second timeout
-        message += '%d new messages produced to topic %s<br/>' % (limit, topic)
-    except Exception as e:
-        message += "ERROR in queries/topic_refresh: cannot produce to public kafka<br/>" + str(e) + '<br/>'
+#    try:
+#        p = Producer(conf)
+#        for out in recent:
+#            jsonout = json.dumps(out, default=datetime_converter)
+#            p.produce(topic, value=jsonout)
+#        p.flush(10.0)   # 10 second timeout
+#        message += '%d new messages produced to topic %s<br/>' % (limit, topic)
+#    except Exception as e:
+#        message += "ERROR in queries/topic_refresh: cannot produce to public kafka<br/>" + str(e) + '<br/>'
     return message
 
 

--- a/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
+++ b/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
@@ -62,7 +62,7 @@
                     {{filterQ.description}}
                 </small>
                 <small class="text-gray-500">
-                    The filter is <b>{% if not filterQ.active %}not active{% elif filterQ.active == 1%} streamed via email{% elif filterQ.active == 2%} streamed via kafka</b> with the topic name <code>{{filterQ.topic_name}}</code><b>{% endif %}.</b> {% include "includes/info_tooltip.html" with info="when active, a filter will be dynamically matched against new transient alerts and the results streamed via email or kafka" position="auto" link=docroot|add:"/core_functions/make_filter.html" %}
+                    The filter is <b>{% if not filterQ.active %}not active{% elif filterQ.active == 1%} streamed via email{% elif filterQ.active == 2%} streamed via kafka</b> with the topic name <code>{{filterQ.topic_name}}</code><b>{% endif %}.</b> {% include "includes/info_tooltip.html" with info="when active, a filter will be dynamically matched against new transient alerts and the results streamed via email or kafka" position="auto" link=docroot|add:"/core_functions/alert-streams.html#kafka-streams" %}
                 </small>
             </div>
 


### PR DESCRIPTION
In the old system, editing a kafka-enabled filter then saving causes three things:
- Deleting the history file
- Deleting the old kafka stream
- Running the new query to get 10 records to put into the new stream

Two problems: first people didn't understand whats happening and second its liable to 'Gateway Timeout' out if the query is complicated.

So I removed the third thing with the 10 records.