### PR TITLE
Hotfix/objectstore

### DIFF
--- a/common/src/objectStore.py
+++ b/common/src/objectStore.py
@@ -8,7 +8,7 @@ class objectStore():
     """objectStore.
     """
 
-    def __init__(self, suffix='txt', fileroot='/data'):
+    def __init__(self, suffix='txt', fileroot='/data', double=False):
         """__init__.
 
         Args:
@@ -19,6 +19,7 @@ class objectStore():
         os.system('mkdir -p ' + fileroot)
         self.fileroot = fileroot
         self.suffix = suffix
+        self.double = double
     
     def getFileName(self, objectId, mkdir=False):
         """getFileName.
@@ -31,6 +32,9 @@ class objectStore():
         # max number of directories 16**3 = 4096
         h = hashlib.md5(objectId.encode())
         dir = h.hexdigest()[:3]
+        if self.double:
+            dir += '/' + h.hexdigest()[3:6]
+
         if mkdir:
             try:
                 os.makedirs(self.fileroot+'/'+dir)

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -241,7 +241,7 @@ def run_ingest(args):
 
     # set up image store in shared file system
     if fitsdir and len(fitsdir) > 0:
-        image_store  = objectStore.objectStore(suffix='fits', fileroot=fitsdir)
+        image_store  = objectStore.objectStore(suffix='fits', fileroot=fitsdir, double=True)
     else:
         log.error('ERROR in ingest/ingestBatch: No image directory found for file storage')
         sys.stdout.flush()

--- a/utility/objectStore1to2.py
+++ b/utility/objectStore1to2.py
@@ -1,0 +1,22 @@
+import os, sys, time
+sys.path.append('../common/src')
+import objectStore
+
+dir1 = '/mnt/cephfs/lasair/fits'
+dir2 = '/mnt/cephfs/lasair/fits2'
+#store1 = objectStore.objectStore(suffix='fits', fileroot=dir1, double=False)
+store2 = objectStore.objectStore(suffix='fits', fileroot=dir2, double=True)
+
+# typical filename = '2267526684315015040_cutoutDifference'
+n = 0
+nfile = 1
+start = time.time()
+for d4 in sorted(os.listdir(dir1)):
+    for filename_fits in os.listdir(dir1 +'/'+ d4):
+        filename = filename_fits.split('.')[0]
+        n2 = store2.getFileName(filename, mkdir=True)
+        cmd = 'cp %s/%s/%s.fits %s' % (dir1, d4, filename, n2)
+        os.system(cmd)
+        nfile += 1
+    t = (time.time() - start)/nfile
+    print('Done %s -- %d files at %.0f ms each' % (d4, nfile, 1000*t))

--- a/utility/objectStore1to2.py
+++ b/utility/objectStore1to2.py
@@ -29,7 +29,7 @@ for i in range(start, 4096, step):
     for filename_fits in os.listdir(dir1 +'/'+ d4):
         filename = filename_fits.split('.')[0]
         n2 = store2.getFileName(filename, mkdir=True)
-        cmd = 'cp %s/%s/%s.fits %s' % (dir1, d4, filename, n2)
+        cmd = 'cp -p %s/%s/%s.fits %s' % (dir1, d4, filename, n2)
         os.system(cmd)
         nfile += 1
     t = (time.time() - tstart)/nfile

--- a/utility/objectStore1to2.py
+++ b/utility/objectStore1to2.py
@@ -2,6 +2,19 @@ import os, sys, time
 sys.path.append('../common/src')
 import objectStore
 
+# How to do multiprocessing
+# python3 objectStore1to2.py 4 0 &
+# python3 objectStore1to2.py 4 1 &
+# python3 objectStore1to2.py 4 2 &
+# python3 objectStore1to2.py 4 3; date
+
+step  = 1
+start = 0
+if len(sys.argv) >=3:
+    step = int(sys.argv[1])
+    start = int(sys.argv[2])
+print('Step %d start %d' % (step, start))
+
 dir1 = '/mnt/cephfs/lasair/fits'
 dir2 = '/mnt/cephfs/lasair/fits2'
 #store1 = objectStore.objectStore(suffix='fits', fileroot=dir1, double=False)
@@ -10,13 +23,14 @@ store2 = objectStore.objectStore(suffix='fits', fileroot=dir2, double=True)
 # typical filename = '2267526684315015040_cutoutDifference'
 n = 0
 nfile = 1
-start = time.time()
-for d4 in sorted(os.listdir(dir1)):
+tstart = time.time()
+for i in range(start, 4096, step):
+    d4 = '%03x' % i
     for filename_fits in os.listdir(dir1 +'/'+ d4):
         filename = filename_fits.split('.')[0]
         n2 = store2.getFileName(filename, mkdir=True)
         cmd = 'cp %s/%s/%s.fits %s' % (dir1, d4, filename, n2)
         os.system(cmd)
         nfile += 1
-    t = (time.time() - start)/nfile
+    t = (time.time() - tstart)/nfile
     print('Done %s -- %d files at %.0f ms each' % (d4, nfile, 1000*t))

--- a/webserver/lasair/lightcurves.py
+++ b/webserver/lasair/lightcurves.py
@@ -51,7 +51,7 @@ class lightcurve_fetcher():
                 candidates.append(cand)
             return candidates
         else:
-            store = objectStore(suffix='json', fileroot=self.fileroot)
+            store = objectStore(suffix='json', fileroot=self.fileroot, double=True)
             lc = store.getObject(objectId)
 
             if not lc:

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -339,7 +339,7 @@ def string2bytes(str):
 
 def fits(request, candid_cutoutType):
     # cutoutType can be cutoutDifference, cutoutTemplate, cutoutScience
-    image_store = objectStore.objectStore(suffix='fits', fileroot=settings.IMAGEFITS)
+    image_store = objectStore.objectStore(suffix='fits', fileroot=settings.IMAGEFITS, double=True)
     try:
         fitsdata = image_store.getFileObject(candid_cutoutType)
     except:


### PR DESCRIPTION
This PR changes the way image cutouts are stored in the CephFS. Instead of having 4096 directories, each with 76,000 files, this "double" version has 4096 directories, each having its own 4096 directories, each having about 18 files. 

The lasair-dev system is now running with this scheme, the ingestion and the webserver. There is a new utility to convert the old system to the new, which ran on 850,000 files in an hour, meaning the 303,000,000 would take about 2 weeks. 

Lets see if this new scheme actually works on lasair-dev when some new alerts come in.