### PR TITLE
somehow public was NULL

### DIFF
--- a/webserver/lasair/apps/watchlist/views.py
+++ b/webserver/lasair/apps/watchlist/views.py
@@ -155,7 +155,7 @@ def watchlist_detail(request, wl_id):
 
     # IS USER ALLOWED TO SEE THIS RESOURCE?
     is_owner = (request.user.is_authenticated) and (request.user.id == watchlist.user.id)
-    is_public = (watchlist.public > 0)
+    is_public = (watchlist.public and watchlist.public > 0)
     is_visible = is_owner or is_public
     if not is_visible:
         messages.error(request, "This watchlist is private and not visible to you")

--- a/webserver/lasair/apps/watchmap/views.py
+++ b/webserver/lasair/apps/watchmap/views.py
@@ -126,7 +126,7 @@ def watchmap_detail(request, ar_id):
 
     # IS USER ALLOWED TO SEE THIS RESOURCE?
     is_owner = (request.user.is_authenticated) and (request.user.id == watchmap.user.id)
-    is_public = (watchmap.public > 0)
+    is_public = (watchmap.public and watchmap.public > 0)
     is_visible = is_owner or is_public
     if not is_visible:
         messages.error(request, "This watchmap is private and not visible to you")


### PR DESCRIPTION
I was not able to see a watchlist it gave Server Error. Somehow it was in the database with `public=NULL`. So this PR means you can still see it. And in my case, delete it. Did the same for watchmaps.
