### PR TITLE
what lasair is not

### DIFF
--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -125,6 +125,13 @@ utilising our flexible schema system. Lasair will add new tables and schemas to
 our databases, and build information systems to make it easy for scientists to 
 navigate the deluge of metadata.
 
+## What Lasair is not
+Lasair is built to process transient alerts rapidly and make the key decision: is this an object I want to follow up? LSST alerts will come at very high rate, and Lasair takes advantage of the design of the distribution system: ["Events are sent in rich alert packets to enable standalone classification"](https://simons.berkeley.edu/sites/default/files/docs/9308/bellmlsst180226.pdf). Thus alerts are judged based only on that rich alert packet, without database interaction, leading to a very fast processing rate.
+
+The "rich data packet" means a year of past data about each object (or a month for the ZTF prototype). Note that Lasair has the full light curves -- available through the object web page or API -- but queries and filters are based on these shorter light curves.
+
+We note that the calibrated ZTF data releases are [hosted at Caltech](https://irsa.ipac.caltech.edu/docs/program_interface/ztf_api.html) and the LSST archives will hosted by [LSST:UK Science Platform](https://rsp.lsst.ac.uk/) and [Rubin Science Platform](https://data.lsst.cloud). These resources may be better suited for long-term archival research.
+
 ## Scientific goals of Lasair
 We aim to facilitate all four science themes of LSST within the Lasair 
 platform: Dark Matter and Dark Energy, the Solar System, the Changing Sky, and 


### PR DESCRIPTION
I have added a note to the documentation explaining that Lasair is for rapid decisions about alerts, not for archival research.
