### PR TITLE
Hotfix/queryfail

### DIFF
--- a/webserver/lasair/apps/filter_query/utils.py
+++ b/webserver/lasair/apps/filter_query/utils.py
@@ -63,7 +63,7 @@ def run_filter(
     if error:
         return None, None, None, None, error
     sqlquery_real = build_query(selected, tables, conditions)
-    sqlquery_limit = sqlquery_real + ' LIMIT %d OFFSET %d' % (limit, offset)
+    sqlquery_limit = 'SET STATEMENT max_statement_time=10 FOR %s LIMIT %d OFFSET %d' % (sqlquery_real, limit, offset)
 
     nalert = 0
     msl = db_connect.readonly()

--- a/webserver/lasair/query_builder.py
+++ b/webserver/lasair/query_builder.py
@@ -49,6 +49,7 @@ select_forbidden_word_list = [
     'high_priority', 'straight_join',
     'sql_small_result', 'sql_big_result', 'sql_buffer_result',
     'sql_no_cache', 'sql_calc_found_rows',
+    'sleep',
 ]
 
 


### PR DESCRIPTION
Some protections against very long running filters in the streaming filter module. 
- There is a `SET STATEMENT max_statement_time=10 FOR` prequel in `run_active_queries`, to limit each to 10 seconds. Most take less than 2 seconds. Also sends email if the timeout is breached.
- When saving a query it is run to pre-inject the kafka with 10 results, and this also has a timeout of 10 seconds.
- The word `SLEEP` is specifically excluded from the SELECT statements
