### PR TITLE
Feature/cutouts

### DIFF
--- a/common/src/objectStore.py
+++ b/common/src/objectStore.py
@@ -1,5 +1,6 @@
 # A simple object store implemented on a file system
 # Roy Williams 2020
+# updated with primary directory as integer MJD
 
 import os
 import hashlib
@@ -8,7 +9,7 @@ class objectStore():
     """objectStore.
     """
 
-    def __init__(self, suffix='txt', fileroot='/data', double=False):
+    def __init__(self, suffix='txt', fileroot='/data'):
         """__init__.
 
         Args:
@@ -19,61 +20,61 @@ class objectStore():
 #        os.system('mkdir -p ' + fileroot)
         self.fileroot = fileroot
         self.suffix = suffix
-        self.double = double
     
-    def getFileName(self, objectId, mkdir=False):
+    def getFileName(self, objectId, imjd, mkdir=False):
         """getFileName.
 
         Args:
             objectId:
+            imjd:
             mkdir:
         """
+        imjddir = self.fileroot +'/' + '%d'%imjd + '/'
+        if mkdir:
+            try: os.makedirs(imjddir)
+            except: pass
+
         # hash the filename for the directory, use the last 3 digits
         # max number of directories 16**3 = 4096
         h = hashlib.md5(objectId.encode())
-        dir = h.hexdigest()[:3]
-        if self.double:
-            dir += '/' + h.hexdigest()[3:6]
-
+        imjddirhash = imjddir + h.hexdigest()[:3] + '/'
         if mkdir:
-            try:
-                os.makedirs(self.fileroot+'/'+dir)
-#                print('%s made %s' % (self.suffix, dir))
-            except:
-                pass
-        return self.fileroot +'/%s/%s.%s' % (dir, objectId, self.suffix)
+            try: os.makedirs(imjddirhash)
+            except: pass
 
-    def getFileObject(self, objectId):
+        return imjddirhash + objectId +'.' + self.suffix
+
+    def getFileObject(self, objectId, imjd):
         """getObject.
 
         Args:
             objectId:
         """
-        f = open(self.getFileName(objectId), 'rb')
+        f = open(self.getFileName(objectId, imjd), 'rb')
         return f
 
-    def getObject(self, objectId):
+    def getObject(self, objectId, imjd):
         """getObject.
 
         Args:
             objectId:
         """
         try:
-            f = open(self.getFileName(objectId))
+            f = open(self.getFileName(objectId, imjd))
             str = f.read()
             f.close()
             return str
         except:
             return None
 
-    def putObject(self, objectId, objectBlob):
+    def putObject(self, objectId, imjd, objectBlob):
         """putObject.
 
         Args:
             objectId:
             objectBlob:
         """
-        filename = self.getFileName(objectId, mkdir=True)
+        filename = self.getFileName(objectId, imjd, mkdir=True)
 #        print(objectId, filename)
         if isinstance(objectBlob, str):
             f = open(filename, 'w')
@@ -81,26 +82,3 @@ class objectStore():
             f = open(filename, 'wb')
         f.write(objectBlob)
         f.close()
-
-    def getObjects(self, objectIdList):
-        """getObjects.
-
-        Args:
-            objectIdList:
-        """
-        # get a bunch of objects from a bunch of identifiers
-        D = {}
-        for objectId in objectIdList:
-            s = self.getObject(objectId)
-            D[objectId] = json.loads(s)
-        return json.dumps(D, indent=2)
-
-    def putObjects(self, objectBlobDict):
-        """putObjects.
-
-        Args:
-            objectBlobDict:
-        """
-        # put a bunch of objects from a dict of objectId:object
-        for (objectId, objectBlob) in objectBlobDict.items():
-            self.putObject(objectId, objectBlob)

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -171,7 +171,7 @@ def handle_alert(alert, image_store, producer, topic_out, cassandra_session):
 
     # store the fits images
     if image_store:
-        imjd = int(alert_noimages['candidate']['jd'] - 2440000.5)
+        imjd = int(alert_noimages['candidate']['jd'] - 2400000.5)
         if store_images(alert, image_store, candid, imjd) == None:
             log.error('ERROR: in ingest/ingest: Failed to put cutouts in file system')
             return None   # ingest batch failed

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -55,14 +55,14 @@ def msg_text(message):
                     if k not in ['cutoutDifference', 'cutoutTemplate', 'cutoutScience']}
     return message_text
 
-def store_images(message, store, candid):
+def store_images(message, store, candid, imjd):
     global log
     try:
         for cutoutType in ['cutoutDifference', 'cutoutTemplate', 'cutoutScience']:
             contentgz = message[cutoutType]['stampData']
             content = zlib.decompress(contentgz, 16+zlib.MAX_WBITS)
             filename = '%d_%s' % (candid, cutoutType)
-            store.putObject(filename, content)
+            store.putObject(filename, imjd, content)
         return 0
     except Exception as e:
         log.error('ERROR in ingest/ingest: ', e)
@@ -171,7 +171,8 @@ def handle_alert(alert, image_store, producer, topic_out, cassandra_session):
 
     # store the fits images
     if image_store:
-        if store_images(alert, image_store, candid) == None:
+        imjd = int(alert_noimages['candidate']['jd'] - 2440000.5)
+        if store_images(alert, image_store, candid, imjd) == None:
             log.error('ERROR: in ingest/ingest: Failed to put cutouts in file system')
             return None   # ingest batch failed
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -69,9 +69,9 @@
 
 
                             <td>{% if cand.candid > 0 %}
-                                {% if cand.image_urls.Science %}<a href='javascript:JS9Popout("/fits/{{ cand.candid }}_cutoutScience");'><small>target</small></a> {% endif %}
-                                {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{ cand.candid }}_cutoutTemplate");'><small>ref</small></a> {% endif %}
-                                {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{ cand.candid }}_cutoutDifference");'><small>diff</small></a> {% endif %}
+				    {% if cand.image_urls.Science %}<a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutScience");'><small>target</small></a> {% endif %}
+				    {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutTemplate");'><small>ref</small></a> {% endif %}
+				    {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutDifference");'><small>diff</small></a> {% endif %}
                             {% endif %}</td>
 
                             <td> {% if cand.candid %}<a tabindex="0" class="disable"  data-bs-html="true"  data-bs-container="body" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-placement="top" data-bs-content='<pre><code>{{cand.json}}</code></pre>'>data</a>{% endif %}</td>

--- a/webserver/lasair/templates/includes/widgets/widget_object_stamps.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_stamps.html
@@ -64,15 +64,15 @@
         <div class="row d-xl-flex align-items-centre">
             <div class="col-4">
                 <h2 class="h6 text-gray-400 mb-0">target</h2>
-                <div class="fitsStamp fits-lite" src="/fits/{{ data.candidates.0.candid }}_cutoutScience"></div>
+		<div class="fitsStamp fits-lite" src="/fits/{{ data.candidates.0.imjd }}/{{ data.candidates.0.candid }}_cutoutScience"></div>
             </div>
             <div class="col-4">
                 <h2 class="h6 text-gray-400 mb-0">reference</h2>
-                <div class="fitsStamp fits-lite" src="/fits/{{ data.candidates.0.candid }}_cutoutTemplate"></div>
+                <div class="fitsStamp fits-lite" src="/fits/{{ data.candidates.0.imjd }}/{{ data.candidates.0.candid }}_cutoutTemplate"></div>
             </div>
             <div class="col-4">
                 <h2 class="h6 text-gray-400 mb-0">difference</h2>
-                <div class="fitsStamp fits-lite" src="/fits/{{ data.candidates.0.candid }}_cutoutDifference"></div>
+		<div class="fitsStamp fits-lite" src="/fits/{{ data.candidates.0.imjd }}/{{ data.candidates.0.candid }}_cutoutDifference"></div>
             </div>
         </div>
     </div>

--- a/webserver/lasair/urls.py
+++ b/webserver/lasair/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path('privacy', TemplateView.as_view(template_name='privacy.html'), name='privacy'),
 
     path('admin/', admin.site.urls),
-    path('fits/<slug:candid_cutoutType>/', fits, name='fits'),
+    path('fits/<int:imjd>/<slug:candid_cutoutType>/', fits, name='fits'),
     path('', include('lasairapi.urls')),
     path('', include('lasair.apps.annotator.urls')),
     path('', include('lasair.apps.db_schema.urls')),

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -197,6 +197,7 @@ def objjson(objectId, full=False):
         json_formatted_str = json.dumps(cand, indent=2)
         cand['json'] = json_formatted_str[1:-1]
         cand['mjd'] = mjd = float(cand['jd']) - 2400000.5
+        cand['imjd'] = int(mjd)
         cand['since_now'] = mjd - now
         if 'candid' in cand:
             count_all_candidates += 1
@@ -209,7 +210,7 @@ def objjson(objectId, full=False):
             cand['image_urls'] = {}
             for cutoutType in ['Science', 'Template', 'Difference']:
                 candid_cutoutType = '%s_cutout%s' % (candid, cutoutType)
-                filename = image_store.getFileName(candid_cutoutType)
+                filename = image_store.getFileName(candid_cutoutType, int(mjd))
                 if 1 == 1 or os.path.exists(filename):
                     url = filename.replace(
                         '/mnt/cephfs/lasair',
@@ -337,12 +338,12 @@ def string2bytes(str):
     return bytes
 
 
-def fits(request, candid_cutoutType):
+def fits(request, imjd, candid_cutoutType):
     # cutoutType can be cutoutDifference, cutoutTemplate, cutoutScience
 #    image_store = objectStore.objectStore(suffix='fits', fileroot=settings.IMAGEFITS, double=True)
     image_store = objectStore.objectStore(suffix='fits', fileroot=settings.IMAGEFITS)
     try:
-        fitsdata = image_store.getFileObject(candid_cutoutType)
+        fitsdata = image_store.getFileObject(candid_cutoutType, imjd)
     except:
         fitsdata = ''
 


### PR DESCRIPTION
I have backported the MJD storage scheme and its running on lasair-dev. Affected code is the ingest module that writes cutout images, and web code that reads them. Example below

Looking at the object
https://lasair-dev.lsst.ac.uk/objects/ZTF23abajpme/

It has only one candidate, and one of the 3 cutouts is here
https://lasair-dev.lsst.ac.uk/fits/60185/2431231504615010009_cutoutScience

That image is in the CephFS in the directory 60185 (note MJD 60185 = 2023 Aug 29)
/mnt/cephfs/lasair/fits/60185/881/2431231504615010009_cutoutScience.fits

