### PR TITLE
Feature/expiration

### DIFF
--- a/services/check_expire.py
+++ b/services/check_expire.py
@@ -5,24 +5,35 @@ import os, sys, math, time, stat
 import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-sys.path.append('../../common')
+sys.path.append('../common')
 import settings
-sys.path.append('../../common/src')
+sys.path.append('../common/src')
 from src import db_connect
 
-warningfmt = """
-Dear %s %s,
-Your active Lasair watchlist will become inactive in about a week without action from you, and there will be no further matching of incoming alerts. To keep it active, go to https://lasair-dev.lsst.ac.uk/watchlists/%d/ then click "Settings", then "Save".
-"""
+lasair_url = 'https://lasair-dev.lsst.ac.uk'
 
-inactivefmt = """
-Dear %s %s,
-Your active Lasair watchlist has become inactive and there will be no further matching of incoming alerts. To make it active again, go to https://lasair-dev.lsst.ac.uk/watchlists/%d/ then click "Settings", "active", then "Save".
-"""
+resources = [
+    {'name':'filter',    'dbname':'myqueries',  'rid': 'mq_id'},
+    {'name':'watchlist', 'dbname':'watchlists', 'rid': 'wl_id'},
+    {'name':'watchmap',  'dbname':'areas',      'rid': 'ar_id'},
+]
 
+messages = {
+'warning':
+"""
+Dear %s,
+Your active Lasair %s will become inactive in about a week without action from you, and there will be no further real-time matching of incoming alerts. This is to relieve pressure on the real-time pipeline. To keep your %s active, go to %s then click "Settings", then "Save".
+""",
+
+'expired':
+"""
+Dear %s,
+Your active Lasair %s has expired and become inactive, and there will be no further matching of incoming alerts. To make your %s active again, go to %s then click "Settings", "active", then "Save".
+""",
+}
 
 def send_email(email, message, message_html=''):
-    print(email, message)
+    print(email, message, message_html)
 #    msg = MIMEMultipart('alternative')
 
 #    msg['Subject'] = 'Lasair: Active watchlist becoming inactive'
@@ -36,48 +47,41 @@ def send_email(email, message, message_html=''):
 #    s.sendmail('donotreply@%s' % settings.LASAIR_URL, email, msg.as_string())
 #    s.quit()
 
-def set_all_expire(msl, days):
+def set_expire(msl, resource, days, rid=None):
     expire = datetime.datetime.now() + datetime.timedelta(days=days)
-    query = 'UPDATE watchlists SET date_expire="%s"' % str(expire)
+    query = 'UPDATE %s SET date_expire="%s"' % (resource['dbname'], str(expire))
+    if rid:
+        query += ' WHERE %s=%d' % (resource['rid'], rid)
     print(query)
     cursor = msl.cursor(buffered=True, dictionary=True)
     cursor.execute(query)
     msl.commit()
 
-def mail_if_expire(msl, days):
+def check_and_send(msl, resource, message_type, days):
     timelimit = datetime.datetime.now() + datetime.timedelta(days=days)
     cursor = msl.cursor(buffered=True, dictionary=True)
-    query = 'SELECT wl_id, name, first_name, last_name, email, date_expire '
-    query += 'FROM watchlists,auth_user WHERE auth_user.id=watchlists.user'
+    query = 'SELECT %s as id, name, first_name, last_name, email, date_expire ' % resource['rid'] 
+    query += 'FROM %s,auth_user WHERE auth_user.id=user' % resource['dbname']
     cursor.execute(query)
     for row in cursor:
-        if row['date_expire'] > timelimit:
-            print(row['wl_id'], 'expiry is post %d days'%days)
-            warning = warningfmt % (row['first_name'], row['last_name'], row['wl_id'])
-            send_email(row['email'], warning, '')
+        if row['date_expire'] and row['date_expire'] < timelimit:
+            rid = row['id']
+            print(rid, 'expiry is post %d days'%days)
+            name = '%s %s' % (row['first_name'], row['last_name'])
+            rname = resource['name']
 
-def inactive_if_expire(msl, days):
-    timelimit = datetime.datetime.now() + datetime.timedelta(days=days)
-    cursor = msl.cursor(buffered=True, dictionary=True)
-    query = 'SELECT wl_id, name, first_name, last_name, email, date_expire '
-    query += 'FROM watchlists,auth_user WHERE auth_user.id=watchlists.user'
-    cursor.execute(query)
-    for row in cursor:
-        if row['date_expire'] > timelimit:
-            print(row['wl_id'], 'setting inactive')
-            cursor2 = msl.cursor(buffered=True, dictionary=True)
-            query = 'UPDATE watchlists SET active=0 WHERE wl_id=%d' % row['wl_id']
-            cursor2.execute(query)
-            inactive = inactivefmt % (row['first_name'], row['last_name'], row['wl_id'])
-            send_email(row['email'], inactive, '')
-    msl.commit()
+            url      = '%s/%ss/%d/' % (lasair_url, rname, rid)
+            url_html = '<a href="%s">%s</a>' % (url, url)
+
+            message_fmt = messages[message_type]
+            message      = message_fmt % (name, rname, rname, url)
+            message_html = message_fmt % (name, rname, rname, url_html)
+
+            send_email(row['email'], message, message_html)
 
 if __name__ == "__main__":
     msl = db_connect.remote()
-#    set_all_expire(msl, days)
-
-    days = 4
-    mail_if_expire(msl, days)
-
-    days = 2
-    inactive_if_expire(msl, days)
+    for r in resources:
+#       set_expire(msl, r, days=10)
+        check_and_send(msl, r, 'warning', days=7)
+        check_and_send(msl, r, 'expired', days=0)

--- a/services/check_expire.py
+++ b/services/check_expire.py
@@ -1,8 +1,29 @@
 """
-check_expire.py
+Expiration warnings and deactivation for active resources 
+    where a resource is a filter, watchlist, or watchmap
+    Checks one or all resources for expiration nearer than DAYS days
+    and if it finds them does action that can be email warning, 
+    or expiration plus email confirmation.
+    The action is taken of the expiration is less than DAYS in the future
+    By default all resources are checked, or just one type of resource,
+    or just one specific resource of given id (rid).
+
+Usage:
+    check_expire.py <action> <days> [<resource>] [<rid>]
+    check_expire.py list
+
+Options:
+      <action>: (set|warning|expiration)
+        set: Choose set to set expiration for some days in the future
+        warning: Choose warning to send email of upcoming expiration 
+        expiration: Choose expiration to send email and deactivate
+      <days>: Days is number of days ahead for expiration
+      Optional: <resource>: choose filter|watchlist|watchmap to run on only one kind of resource
+      Optional: <rid> choose id for resource to run only on that
+
 """
 import os, sys, math, time, stat
-import datetime
+import datetime, docopt
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 sys.path.append('../common')
@@ -10,14 +31,14 @@ import settings
 sys.path.append('../common/src')
 from src import db_connect
 
-lasair_url = 'https://lasair-dev.lsst.ac.uk'
+# What we should call the resource, then the database name of it, then the name of the identifier
+resources = {
+    'filter':    {'dbname':'myqueries',  'rid': 'mq_id'},
+    'watchlist': {'dbname':'watchlists', 'rid': 'wl_id'},
+    'watchmap':  {'dbname':'areas',      'rid': 'ar_id'},
+}
 
-resources = [
-    {'name':'filter',    'dbname':'myqueries',  'rid': 'mq_id'},
-    {'name':'watchlist', 'dbname':'watchlists', 'rid': 'wl_id'},
-    {'name':'watchmap',  'dbname':'areas',      'rid': 'ar_id'},
-]
-
+# The emails we can send out
 messages = {
 'warning':
 """
@@ -25,7 +46,7 @@ Dear %s,
 Your active Lasair %s will become inactive in about a week without action from you, and there will be no further real-time matching of incoming alerts. This is to relieve pressure on the real-time pipeline. To keep your %s active, go to %s then click "Settings", then "Save".
 """,
 
-'expired':
+'expiration':
 """
 Dear %s,
 Your active Lasair %s has expired and become inactive, and there will be no further matching of incoming alerts. To make your %s active again, go to %s then click "Settings", "active", then "Save".
@@ -36,7 +57,7 @@ def send_email(email, message, message_html=''):
     print(email, message, message_html)
 #    msg = MIMEMultipart('alternative')
 
-#    msg['Subject'] = 'Lasair: Active watchlist becoming inactive'
+#    msg['Subject'] = 'Lasair: Active resource becoming inactive'
 #    msg['From']    = 'donotreply@%s' % settings.LASAIR_URL
 #    msg['To']      = email
 
@@ -47,41 +68,114 @@ def send_email(email, message, message_html=''):
 #    s.sendmail('donotreply@%s' % settings.LASAIR_URL, email, msg.as_string())
 #    s.quit()
 
-def set_expire(msl, resource, days, rid=None):
-    expire = datetime.datetime.now() + datetime.timedelta(days=days)
+def list_resources(msl):
+    """
+    List all the active resources
+    """
+    global resources
+    now = datetime.datetime.now()
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    for rname,resource in resources.items():
+        print('Active ', rname)
+        query = 'SELECT %s as id, name, first_name, last_name, email, date_expire ' % resource['rid'] 
+        query += 'FROM %s,auth_user WHERE auth_user.id=user AND active>0 ' % resource['dbname']
+        query += 'ORDER BY  date_expire'
+        cursor.execute(query)
+        for row in cursor:
+            name = '[%s %s]' % (row['first_name'], row['last_name'])
+            until = row['date_expire'] - now
+            print('   %5d expires %.1f daysAhead %s %s' % (row['id'], until.days, name, row['name']))
+
+def set_expire(msl, resource, daysAhead, rid=None):
+    """
+    Set the given resource expiration dates in the future
+    if the resource id (rid) is None, it does all of them
+    """
+    expire = datetime.datetime.now() + datetime.timedelta(days=daysAhead)
     query = 'UPDATE %s SET date_expire="%s"' % (resource['dbname'], str(expire))
     if rid:
-        query += ' WHERE %s=%d' % (resource['rid'], rid)
+        query += ' WHERE %s=%s' % (resource['rid'], rid)
     print(query)
     cursor = msl.cursor(buffered=True, dictionary=True)
     cursor.execute(query)
     msl.commit()
 
-def check_and_send(msl, resource, message_type, days):
-    timelimit = datetime.datetime.now() + datetime.timedelta(days=days)
+def make_inactive(msl, resource, rid):
+    """
+    The actual teeth of the thing. Switches the given resource to inactive.
+    """
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    query = 'UPDATE %s SET active=0 where %s=%s'
+    query = query % (resource['dbname'], resource['rid'], rid)
+    print(query)
+    cursor.execute(query)
+    msl.commit()
+
+def check_and_action(msl, rname, resource, action, daysAhead, rid=None):
+    """
+    Check all the given resources for a warning message of for actual expiration.
+    if the resource id (rid) is None, it does all of them
+    """
+    if rid:
+        print('Checking expiration for %s with %s, rid=%s' % (rname, action, rid))
+    else:
+        print('Checking expiration for %s with %s, rid=All' % (rname, action))
+    timelimit = datetime.datetime.now() + datetime.timedelta(days=daysAhead)
     cursor = msl.cursor(buffered=True, dictionary=True)
     query = 'SELECT %s as id, name, first_name, last_name, email, date_expire ' % resource['rid'] 
-    query += 'FROM %s,auth_user WHERE auth_user.id=user' % resource['dbname']
+    query += 'FROM %s,auth_user WHERE auth_user.id=user AND active>0 ' % resource['dbname']
+    if rid:
+        query += 'AND id=%s' % rid
     cursor.execute(query)
     for row in cursor:
         if row['date_expire'] and row['date_expire'] < timelimit:
             rid = row['id']
-            print(rid, 'expiry is post %d days'%days)
+            print(rid, 'expiry is post %d daysAhead'%daysAhead)
             name = '%s %s' % (row['first_name'], row['last_name'])
-            rname = resource['name']
 
-            url      = '%s/%ss/%d/' % (lasair_url, rname, rid)
+            url      = '%s/%ss/%d/' % (settings.LASAIR_URL, rname, rid)
             url_html = '<a href="%s">%s</a>' % (url, url)
 
-            message_fmt = messages[message_type]
+            message_fmt = messages[action]
             message      = message_fmt % (name, rname, rname, url)
             message_html = message_fmt % (name, rname, rname, url_html)
 
             send_email(row['email'], message, message_html)
+            if message == 'expiration':
+                make_inactive(msl, resource, rid)
 
 if __name__ == "__main__":
+    args = docopt.docopt(__doc__)
+    action = args['<action>']
+    rname  = args['<resource>']
+    rid    = args['<rid>']
+    
+    print(args)
     msl = db_connect.remote()
-    for r in resources:
-#       set_expire(msl, r, days=10)
-        check_and_send(msl, r, 'warning', days=7)
-        check_and_send(msl, r, 'expired', days=0)
+
+    if args['list']:
+        list_resources(msl)
+        sys.exit()
+
+    daysAhead   = int(args['<days>'])
+
+    if action == 'set':
+        if not rname:
+            for  rname,resource in resources.items():
+                set_expire(msl, resource, daysAhead, rid=rid)
+        elif rname in resources:
+            set_expire(msl, resources[rname], daysAhead, rid=rid)
+        else:
+            print('Resource name %s not recognised, must be in %s' % (rname, resources.keys()))
+
+    elif action == 'warning' or action == 'expiration':
+        if not rname:
+            for  rname,resource in resources.items():
+                check_and_action(msl, rname, resource, action, daysAhead)
+        elif rname in resources:
+            check_and_action(msl, rname, resources[rname], action, daysAhead, rid)
+        else:
+            print('Resource name %s not recognised, must be in %s' % (rname, resources.keys()))
+
+    else:
+        print('Action %s not recognised, must be in list|set|warning|expiration' % action)

--- a/services/check_expire.py
+++ b/services/check_expire.py
@@ -9,21 +9,21 @@ Expiration warnings and deactivation for active resources
     or just one specific resource of given id (rid).
 
 Usage:
-    check_expire.py <action> <days> [<resource>] [<rid>]
-    check_expire.py list
+    check_expire.py --action=<action> --days=<days> [--resource=<resource>] [--rid=<rid>] [--log]
+    check_expire.py --list
 
 Options:
-      <action>: (set|warning|expiration)
+     --list: List all the active resources
+      --action=<action>: (set|warning|expiration)
         set: Choose set to set expiration for some days in the future
         warning: Choose warning to send email of upcoming expiration 
         expiration: Choose expiration to send email and deactivate
-      <days>: Days is number of days ahead for expiration
-      Optional: <resource>: choose filter|watchlist|watchmap to run on only one kind of resource
-      Optional: <rid> choose id for resource to run only on that
+      --days=<days>: Days is number of days ahead for expiration
+      --resource=<resource>: choose filter|watchlist|watchmap to run on only one kind of resource
+      --rid=<rid> choose id for resource to run only on that
 
 """
-import os, sys, math, time, stat
-import datetime, docopt
+import os, sys, math, time, smtplib, datetime, docopt
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 sys.path.append('../common')
@@ -43,30 +43,43 @@ messages = {
 'warning':
 """
 Dear %s,
-Your active Lasair %s will become inactive in about a week without action from you, and there will be no further real-time matching of incoming alerts. This is to relieve pressure on the real-time pipeline. To keep your %s active, go to %s then click "Settings", then "Save".
+Your active Lasair %s will become inactive on %s without action from you, and there will be no further real-time matching of incoming alerts. This is to relieve pressure on the real-time pipeline. To keep your %s active, go to %s then click "Settings", then "Save"
 """,
 
 'expiration':
 """
 Dear %s,
-Your active Lasair %s has expired and become inactive, and there will be no further matching of incoming alerts. To make your %s active again, go to %s then click "Settings", "active", then "Save".
+Your active Lasair %s has recently expired and thus become inactive, and there will be no further matching of incoming alerts. To make your %s active again, go to %s then click "Settings", "Active" or "Streaming", then "Save".
 """,
 }
 
+def log(out):
+    global logfile
+    if logfile:
+        try:
+            f = open(logfile, 'a')
+        except:
+            print("ERROR: Cannot open system logfile %s:%s" % (logfile, str(e)))
+        f.write(out+'\n')
+        f.close
+    else:
+        print(out)
+
 def send_email(email, message, message_html=''):
-    print(email, message, message_html)
-#    msg = MIMEMultipart('alternative')
+#    print(email, message, message_html)
+    msg = MIMEMultipart('alternative')
 
-#    msg['Subject'] = 'Lasair: Active resource becoming inactive'
-#    msg['From']    = 'donotreply@%s' % settings.LASAIR_URL
-#    msg['To']      = email
+    msg['Subject'] = 'Lasair: Active resource becoming inactive'
+    msg['From']    = 'lasair@lsst.ac.uk'
+    msg['To']      = email
 
-#    msg.attach(MIMEText(message, 'plain'))
-#    if len(message_html) > 0:
-#        msg.attach(MIMEText(message_html, 'html'))
-#    s = smtplib.SMTP('localhost')
-#    s.sendmail('donotreply@%s' % settings.LASAIR_URL, email, msg.as_string())
-#    s.quit()
+    msg.attach(MIMEText(message, 'plain'))
+    if len(message_html) > 0:
+        msg.attach(MIMEText(message_html, 'html'))
+    s = smtplib.SMTP('localhost')
+    s.sendmail('lasair@lsst.ac.uk', email, msg.as_string())
+    s.quit()
+    log('Expiry email sent to %s' % email)
 
 def list_resources(msl):
     """
@@ -84,7 +97,7 @@ def list_resources(msl):
         for row in cursor:
             name = '[%s %s]' % (row['first_name'], row['last_name'])
             until = row['date_expire'] - now
-            print('   %5d expires %.1f daysAhead %s %s' % (row['id'], until.days, name, row['name']))
+            print('   %5d expires %.1f days ahead %s %s' % (row['id'], until.days, name, row['name']))
 
 def set_expire(msl, resource, daysAhead, rid=None):
     """
@@ -95,7 +108,9 @@ def set_expire(msl, resource, daysAhead, rid=None):
     query = 'UPDATE %s SET date_expire="%s"' % (resource['dbname'], str(expire))
     if rid:
         query += ' WHERE %s=%s' % (resource['rid'], rid)
-    print(query)
+        print('Setting %s:%s expiry %d days ahead' % (resource['dbname'], rid, daysAhead))
+    else:
+        print('Setting all %s expiry %d days ahead' % (resource['dbname'], daysAhead))
     cursor = msl.cursor(buffered=True, dictionary=True)
     cursor.execute(query)
     msl.commit()
@@ -107,9 +122,13 @@ def make_inactive(msl, resource, rid):
     cursor = msl.cursor(buffered=True, dictionary=True)
     query = 'UPDATE %s SET active=0 where %s=%s'
     query = query % (resource['dbname'], resource['rid'], rid)
-    print(query)
     cursor.execute(query)
     msl.commit()
+    log('Made %s:%s inactive' % (resource['dbname'], rid))
+
+def nice_date(dt):
+    tok = str(dt).split()
+    return tok[0]
 
 def check_and_action(msl, rname, resource, action, daysAhead, rid=None):
     """
@@ -117,46 +136,58 @@ def check_and_action(msl, rname, resource, action, daysAhead, rid=None):
     if the resource id (rid) is None, it does all of them
     """
     if rid:
-        print('Checking expiration for %s with %s, rid=%s' % (rname, action, rid))
+        log('Checking expiration for %s with %s, rid=%s' % (rname, action, rid))
     else:
-        print('Checking expiration for %s with %s, rid=All' % (rname, action))
+        log('Checking expiration for %s with %s, rid=All' % (rname, action))
     timelimit = datetime.datetime.now() + datetime.timedelta(days=daysAhead)
     cursor = msl.cursor(buffered=True, dictionary=True)
     query = 'SELECT %s as id, name, first_name, last_name, email, date_expire ' % resource['rid'] 
     query += 'FROM %s,auth_user WHERE auth_user.id=user AND active>0 ' % resource['dbname']
     if rid:
-        query += 'AND id=%s' % rid
+        query += 'AND %s=%s' % (resource['rid'], rid)
     cursor.execute(query)
     for row in cursor:
         if row['date_expire'] and row['date_expire'] < timelimit:
             rid = row['id']
-            print(rid, 'expiry is post %d daysAhead'%daysAhead)
+            log('expiry for %s:%s is after %d daysAhead'% (rname, rid, daysAhead))
             name = '%s %s' % (row['first_name'], row['last_name'])
 
-            url      = '%s/%ss/%d/' % (settings.LASAIR_URL, rname, rid)
+            url      = 'https://%s/%ss/%d/' % (settings.LASAIR_URL, rname, rid)
             url_html = '<a href="%s">%s</a>' % (url, url)
-
             message_fmt = messages[action]
-            message      = message_fmt % (name, rname, rname, url)
-            message_html = message_fmt % (name, rname, rname, url_html)
 
-            send_email(row['email'], message, message_html)
-            if message == 'expiration':
+            if action == 'expiration':
+                message      = message_fmt % (name, rname, rname, url)
+                message_html = message_fmt % (name, rname, rname, url_html)
                 make_inactive(msl, resource, rid)
+                send_email(row['email'], message, message_html)
+
+            if action == 'warning':
+                niceexpire = nice_date(row['date_expire'])
+                message      = message_fmt % (name, rname, niceexpire, rname, url)
+                message_html = message_fmt % (name, rname, niceexpire, rname, url_html)
+                send_email(row['email'], message, message_html)
 
 if __name__ == "__main__":
+    global logfile
     args = docopt.docopt(__doc__)
-    action = args['<action>']
-    rname  = args['<resource>']
-    rid    = args['<rid>']
+    action = args['--action']
+    rname  = args['--resource']
+    rid    = args['--rid']
+
+    if args['--log']:
+        today = datetime.datetime.today().strftime('%Y%m%d')
+        logfile = settings.SERVICES_LOG +'/'+ today + '.log'
+    else:
+        logfile = None
     
     msl = db_connect.remote()
 
-    if args['list']:
+    if args['--list']:
         list_resources(msl)
         sys.exit()
 
-    daysAhead   = int(args['<days>'])
+    daysAhead   = int(args['--days'])
 
     if action == 'set':
         if not rname:
@@ -165,7 +196,7 @@ if __name__ == "__main__":
         elif rname in resources:
             set_expire(msl, resources[rname], daysAhead, rid=rid)
         else:
-            print('Resource name %s not recognised, must be in %s' % (rname, resources.keys()))
+            log('Resource name %s not recognised, must be in %s' % (rname, resources.keys()))
 
     elif action == 'warning' or action == 'expiration':
         if not rname:
@@ -174,7 +205,7 @@ if __name__ == "__main__":
         elif rname in resources:
             check_and_action(msl, rname, resources[rname], action, daysAhead, rid)
         else:
-            print('Resource name %s not recognised, must be in %s' % (rname, resources.keys()))
+            log('Resource name %s not recognised, must be in %s' % (rname, resources.keys()))
 
     else:
-        print('Action %s not recognised, must be in list|set|warning|expiration' % action)
+        log('Action %s not recognised, must be in list|set|warning|expiration' % action)

--- a/services/check_expire.py
+++ b/services/check_expire.py
@@ -150,7 +150,6 @@ if __name__ == "__main__":
     rname  = args['<resource>']
     rid    = args['<rid>']
     
-    print(args)
     msl = db_connect.remote()
 
     if args['list']:

--- a/services/check_expire.py
+++ b/services/check_expire.py
@@ -79,7 +79,7 @@ def send_email(email, message, message_html=''):
     s = smtplib.SMTP('localhost')
     s.sendmail('lasair@lsst.ac.uk', email, msg.as_string())
     s.quit()
-    log('Expiry email sent to %s' % email)
+    log('Email sent to %s' % email)
 
 def list_resources(msl):
     """
@@ -149,7 +149,7 @@ def check_and_action(msl, rname, resource, action, daysAhead, rid=None):
     for row in cursor:
         if row['date_expire'] and row['date_expire'] < timelimit:
             rid = row['id']
-            log('expiry for %s:%s is after %d daysAhead'% (rname, rid, daysAhead))
+            log('expiry for %s:%s is after %d days ahead'% (rname, rid, daysAhead))
             name = '%s %s' % (row['first_name'], row['last_name'])
 
             url      = 'https://%s/%ss/%d/' % (settings.LASAIR_URL, rname, rid)

--- a/services/check_expire.py
+++ b/services/check_expire.py
@@ -1,0 +1,83 @@
+"""
+check_expire.py
+"""
+import os, sys, math, time, stat
+import datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+sys.path.append('../../common')
+import settings
+sys.path.append('../../common/src')
+from src import db_connect
+
+warningfmt = """
+Dear %s %s,
+Your active Lasair watchlist will become inactive in about a week without action from you, and there will be no further matching of incoming alerts. To keep it active, go to https://lasair-dev.lsst.ac.uk/watchlists/%d/ then click "Settings", then "Save".
+"""
+
+inactivefmt = """
+Dear %s %s,
+Your active Lasair watchlist has become inactive and there will be no further matching of incoming alerts. To make it active again, go to https://lasair-dev.lsst.ac.uk/watchlists/%d/ then click "Settings", "active", then "Save".
+"""
+
+
+def send_email(email, message, message_html=''):
+    print(email, message)
+#    msg = MIMEMultipart('alternative')
+
+#    msg['Subject'] = 'Lasair: Active watchlist becoming inactive'
+#    msg['From']    = 'donotreply@%s' % settings.LASAIR_URL
+#    msg['To']      = email
+
+#    msg.attach(MIMEText(message, 'plain'))
+#    if len(message_html) > 0:
+#        msg.attach(MIMEText(message_html, 'html'))
+#    s = smtplib.SMTP('localhost')
+#    s.sendmail('donotreply@%s' % settings.LASAIR_URL, email, msg.as_string())
+#    s.quit()
+
+def set_all_expire(msl, days):
+    expire = datetime.datetime.now() + datetime.timedelta(days=days)
+    query = 'UPDATE watchlists SET date_expire="%s"' % str(expire)
+    print(query)
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    cursor.execute(query)
+    msl.commit()
+
+def mail_if_expire(msl, days):
+    timelimit = datetime.datetime.now() + datetime.timedelta(days=days)
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    query = 'SELECT wl_id, name, first_name, last_name, email, date_expire '
+    query += 'FROM watchlists,auth_user WHERE auth_user.id=watchlists.user'
+    cursor.execute(query)
+    for row in cursor:
+        if row['date_expire'] > timelimit:
+            print(row['wl_id'], 'expiry is post %d days'%days)
+            warning = warningfmt % (row['first_name'], row['last_name'], row['wl_id'])
+            send_email(row['email'], warning, '')
+
+def inactive_if_expire(msl, days):
+    timelimit = datetime.datetime.now() + datetime.timedelta(days=days)
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    query = 'SELECT wl_id, name, first_name, last_name, email, date_expire '
+    query += 'FROM watchlists,auth_user WHERE auth_user.id=watchlists.user'
+    cursor.execute(query)
+    for row in cursor:
+        if row['date_expire'] > timelimit:
+            print(row['wl_id'], 'setting inactive')
+            cursor2 = msl.cursor(buffered=True, dictionary=True)
+            query = 'UPDATE watchlists SET active=0 WHERE wl_id=%d' % row['wl_id']
+            cursor2.execute(query)
+            inactive = inactivefmt % (row['first_name'], row['last_name'], row['wl_id'])
+            send_email(row['email'], inactive, '')
+    msl.commit()
+
+if __name__ == "__main__":
+    msl = db_connect.remote()
+#    set_all_expire(msl, days)
+
+    days = 4
+    mail_if_expire(msl, days)
+
+    days = 2
+    inactive_if_expire(msl, days)

--- a/services/make_area_files.py
+++ b/services/make_area_files.py
@@ -61,10 +61,10 @@ def fetch_active_areas(msl, cache_dir):
 
     keep = []
     get  = []
-    cursor.execute('SELECT ar_id, name, timestamp FROM areas WHERE active > 0 ')
+    cursor.execute('SELECT ar_id, name, date_modified FROM areas WHERE active > 0 ')
     for row in cursor:
         # unix time of last update from the database
-        area_timestamp = time.mktime(row['timestamp'].timetuple())
+        area_timestamp = time.mktime(row['date_modified'].timetuple())
 
         # directory where the cache files are kept
         area_file = cache_dir + '/ar_%d.fits'%row['ar_id']

--- a/services/make_watchlist_files.py
+++ b/services/make_watchlist_files.py
@@ -114,10 +114,10 @@ def fetch_active_watchlists(msl, cache_dir):
 
     keep = []
     get  = []
-    cursor.execute('SELECT wl_id, name, radius, timestamp FROM watchlists WHERE active > 0 ')
+    cursor.execute('SELECT wl_id, name, radius, date_modified FROM watchlists WHERE active > 0 ')
     for row in cursor:
         # unix time of last update from the database
-        watchlist_timestamp = time.mktime(row['timestamp'].timetuple())
+        watchlist_timestamp = time.mktime(row['date_modified'].timetuple())
 
         # directory where the cache files are kept
         watchlist_dir = cache_dir + '/wl_%d'%row['wl_id']

--- a/webserver/lasair/apps/filter_query/models.py
+++ b/webserver/lasair/apps/filter_query/models.py
@@ -17,8 +17,10 @@ class filter_query(models.Model):
     active = models.IntegerField(blank=True, null=True)
     topic_name = models.CharField(max_length=256, blank=True, null=True)
     real_sql = models.CharField(max_length=4096, blank=True, null=True)
-    date_created = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
-    date_modified = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
+    date_created  = models.DateTimeField(auto_now_add=True, editable=False, blank=True, null=True)
+    date_modified = models.DateTimeField(auto_now=    True, editable=False, blank=True, null=True)
+    date_expire   = models.DateTimeField(                   editable=True,  blank=True, null=True)
+
 
     class Meta:
         """Meta.

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -18,7 +18,7 @@ import json
 import re
 import copy
 import time
-from datetime import datetime
+import datetime
 from django.contrib import messages
 import os
 import sys
@@ -121,6 +121,9 @@ def filter_query_detail(request, mq_id, action=False):
             else:
                 filterQuery.public = 0
 
+            filterQuery.date_expire = \
+                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+
             # REFRESH STREAM
             message = ''
             tn = topic_name(request.user.id, filterQuery.name)
@@ -152,6 +155,10 @@ def filter_query_detail(request, mq_id, action=False):
             newFil.public = True
         else:
             newFil.public = False
+
+        newFil.date_expire = \
+            datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+
         newFil.save()
         filterQuery = newFil
         mq_id = filterQuery.pk
@@ -376,6 +383,9 @@ def filter_query_create(request, mq_id=False):
                                            selected=selected, conditions=conditions, tables=tables,
                                            real_sql=sqlquery_real, topic_name=tn)
                 verb = "created"
+
+            filterQuery.date_expire = \
+                datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
 
             filterQuery.save()
 

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -122,7 +122,7 @@ def filter_query_detail(request, mq_id, action=False):
                 filterQuery.public = 0
 
             filterQuery.date_expire = \
-                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                    datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
             # REFRESH STREAM
             message = ''
@@ -157,7 +157,7 @@ def filter_query_detail(request, mq_id, action=False):
             newFil.public = False
 
         newFil.date_expire = \
-            datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+            datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
         newFil.save()
         filterQuery = newFil
@@ -385,7 +385,7 @@ def filter_query_create(request, mq_id=False):
                 verb = "created"
 
             filterQuery.date_expire = \
-                datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
             filterQuery.save()
 

--- a/webserver/lasair/apps/watchlist/models.py
+++ b/webserver/lasair/apps/watchlist/models.py
@@ -34,9 +34,9 @@ class Watchlist(models.Model):
     active = models.BooleanField(blank=True, null=True)
     public = models.BooleanField(blank=True, null=True)
     radius = models.FloatField(blank=True, null=True)
-    timestamp = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
-    date_created = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
-    date_modified = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
+    date_created  = models.DateTimeField(auto_now_add=True, editable=False, blank=True, null=True)
+    date_modified = models.DateTimeField(auto_now=    True, editable=False, blank=True, null=True)
+    date_expire   = models.DateTimeField(                   editable=True,  blank=True, null=True)
 
     class Meta:
         """Meta.

--- a/webserver/lasair/apps/watchlist/views.py
+++ b/webserver/lasair/apps/watchlist/views.py
@@ -92,7 +92,7 @@ def watchlist_index(request):
                 except Exception as e:
                     messages.error(request, f'Bad line {len(cone_list)}: {line}\n{str(e)}')
 
-            expire = datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+            expire = datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
             wl = Watchlist(user=request.user, name=name, description=description, active=active, public=public, radius=default_radius, date_expire=expire)
             wl.save()
             cones = []
@@ -190,7 +190,7 @@ def watchlist_detail(request, wl_id):
                     watchlist.radius = 360
 
                 watchlist.date_expire = \
-                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                    datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
                 watchlist.save()
                 messages.success(request, f'Your watchlist has been successfully updated')
@@ -222,7 +222,7 @@ def watchlist_detail(request, wl_id):
                 newWl.public = False
 
             newWl.date_expire = \
-                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                    datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
             newWl.save()
             wl = newWl
 

--- a/webserver/lasair/apps/watchlist/views.py
+++ b/webserver/lasair/apps/watchlist/views.py
@@ -3,6 +3,7 @@ from .forms import WatchlistForm, UpdateWatchlistForm, DuplicateWatchlistForm
 import time
 import random
 import json
+import datetime
 from subprocess import Popen, PIPE
 from lasair.apps.watchlist.models import Watchlist, WatchlistCone
 from django.http import HttpResponse, HttpResponseRedirect
@@ -91,7 +92,8 @@ def watchlist_index(request):
                 except Exception as e:
                     messages.error(request, f'Bad line {len(cone_list)}: {line}\n{str(e)}')
 
-            wl = Watchlist(user=request.user, name=name, description=description, active=active, public=public, radius=default_radius)
+            expire = datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+            wl = Watchlist(user=request.user, name=name, description=description, active=active, public=public, radius=default_radius, date_expire=expire)
             wl.save()
             cones = []
             for cone in cone_list:
@@ -186,6 +188,10 @@ def watchlist_detail(request, wl_id):
                 watchlist.radius = float(request.POST.get('radius'))
                 if watchlist.radius > 360:
                     watchlist.radius = 360
+
+                watchlist.date_expire = \
+                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+
                 watchlist.save()
                 messages.success(request, f'Your watchlist has been successfully updated')
         # REQUEST TO REFRESH THE WATCHLIST MATCHES
@@ -214,6 +220,9 @@ def watchlist_detail(request, wl_id):
                 newWl.public = True
             else:
                 newWl.public = False
+
+            newWl.date_expire = \
+                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
             newWl.save()
             wl = newWl
 

--- a/webserver/lasair/apps/watchmap/models.py
+++ b/webserver/lasair/apps/watchmap/models.py
@@ -14,9 +14,9 @@ class Watchmap(models.Model):
     mocimage = models.TextField(blank=True, null=True)
     active = models.BooleanField(blank=True, null=True)
     public = models.BooleanField(blank=True, null=True)
-    timestamp = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
-    date_created = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
-    date_modified = models.DateTimeField(auto_now=True, editable=False, blank=True, null=True)
+    date_created  = models.DateTimeField(auto_now_add=True, editable=False, blank=True, null=True)
+    date_modified = models.DateTimeField(auto_now=    True, editable=False, blank=True, null=True)
+    date_expire   = models.DateTimeField(                   editable=True,  blank=True, null=True)
 
     class Meta:
         """Meta.

--- a/webserver/lasair/apps/watchmap/views.py
+++ b/webserver/lasair/apps/watchmap/views.py
@@ -5,6 +5,7 @@ import tempfile
 import io
 import time
 import json
+import datetime
 import matplotlib.pyplot as plt
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -70,8 +71,10 @@ def watchmap_index(request):
                 png_bytes = make_image_of_MOC(fits_bytes, request=request)
                 png_string = bytes2string(png_bytes)
 
+                expire = datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+
                 wm = Watchmap(user=request.user, name=name, description=description,
-                              moc=fits_string, mocimage=png_string, active=active, public=public)
+                    moc=fits_string, mocimage=png_string, active=active, public=public, date_expire=expire)
                 wm.save()
                 watchmapname = form.cleaned_data.get('name')
                 messages.success(request, f"The '{watchmapname}' watchmap has been successfully created")
@@ -154,6 +157,8 @@ def watchmap_detail(request, ar_id):
                         watchmap.public = 1
                     else:
                         watchmap.public = 0
+                    watchmap.date_expire = \
+                        datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
                     watchmap.save()
                     messages.success(request, f'Your watchmap has been successfully updated')
     elif request.method == 'POST' and action == "copy":
@@ -175,6 +180,10 @@ def watchmap_detail(request, ar_id):
                 newWm.public = True
             else:
                 newWm.public = False
+
+            newWm.date_expire = \
+                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+
             newWm.save()
             wm = newWm
             ar_id = wm.pk

--- a/webserver/lasair/apps/watchmap/views.py
+++ b/webserver/lasair/apps/watchmap/views.py
@@ -71,7 +71,7 @@ def watchmap_index(request):
                 png_bytes = make_image_of_MOC(fits_bytes, request=request)
                 png_string = bytes2string(png_bytes)
 
-                expire = datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                expire = datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
                 wm = Watchmap(user=request.user, name=name, description=description,
                     moc=fits_string, mocimage=png_string, active=active, public=public, date_expire=expire)
@@ -158,7 +158,7 @@ def watchmap_detail(request, ar_id):
                     else:
                         watchmap.public = 0
                     watchmap.date_expire = \
-                        datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                        datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
                     watchmap.save()
                     messages.success(request, f'Your watchmap has been successfully updated')
     elif request.method == 'POST' and action == "copy":
@@ -182,7 +182,7 @@ def watchmap_detail(request, ar_id):
                 newWm.public = False
 
             newWm.date_expire = \
-                    datetime.datetime.now() + datetime.timedelta(days=30*settings.ACTIVE_EXPIRE)
+                    datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
             newWm.save()
             wm = newWm


### PR DESCRIPTION
First define "resource" as filter or watchlist or watchmap

(1) for all three:
edit webserver/lasair/apps/<resource>/models.py
```
    date_created  = models.DateTimeField(auto_now_add=True, editable=False, blank=True, null=True)
    date_modified = models.DateTimeField(auto_now=    True, editable=False, blank=True, null=True)
    date_expire   = models.DateTimeField(                   editable=True,  blank=True, null=True)
```

(2) remove "timestamp" from models, same as "date_modified"

(3) added ACTIVE_EXPIRE = 6 to webserver/lasair/settings.py

(4) tried makemigrations but it said said nothing to be done
so just did it by hand
```
alter table watchlists drop column timestamp
alter table watchlists add  column date_expire datetime(6) DEFAULT NULL
alter table areas      add  column date_expire datetime(6) DEFAULT NULL
alter table myqueries  add  column date_expire datetime(6) DEFAULT NULL
```

(5) made `check_expire.py` that will be in crontabs eventually, with email properly configured
Some example use
```
cd lasair4/services
list all active resources
python3 check_expire.py --action=list

set all watchmaps expiration 20 days ahead
python3 check_expire.py --action=set --days=20 --resource=watchmap

set watchmap 43 expiration 20 days ahead
python3 check_expire.py --action=set --days=20 --resource=watchmap --rid=43

send out warning emails about every resource with less than 44 days
python3 check_expire.py --action=warning --days=44

same but just watchmaps
python3 check_expire.py --action=warning --days=44 --resource=watchmap

same but just watchmap 43
python3 check_expire.py --action=warning --days=44 --resource=watchmap --rid=43

same stuff but for actual expiration, will also set inactive
python3 check_expire.py --action=expiration --days=22
python3 check_expire.py --action=expiration --days=22 --resource=watchmap
python3 check_expire.py --action=expiration --days=22 --resource=watchmap --rid=43
```