### PR TITLE
fixed slug problem

### DIFF
--- a/webserver/lasair/apps/filter_query/urls.py
+++ b/webserver/lasair/apps/filter_query/urls.py
@@ -8,6 +8,5 @@ urlpatterns = [
     path('filters/<int:mq_id>/update/', views.filter_query_create, name='filter_query_update'),
     path('filters/<int:mq_id>/', views.filter_query_detail, name='filter_query_detail'),
     path('filters/<int:mq_id>/<slug:action>/', views.filter_query_detail, name='filter_query_detail_run'),
-    path('filters/log/<slug:topic>/', views.filter_query_log, name='filter_query_log'),
-
+    path('filters/log/(?P<topic>[-a-zA-Z0-9_.]+)/', views.filter_query_log, name='filter_query_log'),
 ]


### PR DESCRIPTION
In [urls.py](https://github.com/lsst-uk/lasair4/blob/main/webserver/lasair/apps/filter_query/urls.py#L11) we see
```
path('filters/log/<slug:topic>/', views.filter_query_log, name='filter_query_log'),
```
And a slug is defined [here](https://docs.djangoproject.com/en/4.2/ref/models/fields/#slugfield) as: "a short label for something, containing only letters, numbers, underscores or hyphens."

But [here](https://github.com/lsst-uk/lasair4/blob/main/webserver/lasair/apps/filter_query/utils.py#L131) our code allows the dot in the topic name
```
name = ''.join(e for e in name if e.isalnum() or e == '_' or e == '-' or e == '.')
```

So I relaxed the slug in the url so it also allows the dot. 