### PR TITLE
Feature/forced phot

### DIFF
--- a/docs/source/concepts/lightcurve.md
+++ b/docs/source/concepts/lightcurve.md
@@ -9,6 +9,12 @@ Since each source brightness is measured for a specific optical filter, there ma
 several lightcurves for a given object, for example the g-lightcurve and r-lightcurve will
 be derived from the detections in the g filter and r filter respectively.
 
+It is only when an object is more than 5 sigma over the reference imagery that a transient alert is sent out, 
+this is the "unforced" photometry plotted in the object pages. Other brightness measurements are also computed 
+from the imagery, the "forced" photometry at the location of the transient. In each case, what is measured is 
+a "difference" brightness from the reference image, which can be positive or negative.
+More information about forced photometry and ZTF can be found <a href=https://arxiv.org/abs/2305.16279>here</a>.
+
 The nature of the lightcurve informs us of the underlying astrophysics. Variable stars can be characterised
 by the shape of their lightcurves, and explosive transients such as supernovae can be distinguished by the 
 rise and fall rates of their lightcurves.

--- a/docs/source/concepts/lightcurve.md
+++ b/docs/source/concepts/lightcurve.md
@@ -1,20 +1,13 @@
 # Lightcurve
 
-A lightcurve is a record of the brightness of an astrophysical object with time, so it is a collection of 
-(time, brightness) pairs. For LSST the brightness is measured as flux in nanoJanskies (nJ), and for ZTF it
-is measured with the traditional magnitude system. Note that the values in the lightcurve are *difference*
-fluxes, as defined in [Objects and Sources](objects_sources.html).
+A lightcurve is a record of the brightness of an astrophysical object with time, so it is a collection of (time, brightness) pairs. For LSST the brightness of sources are calibrated and provided in flux, in the units of nanoJanskies (nJ). In ZTF the brightness measurement is provided as an AB magnitude.Note that the values in the lightcurve are *difference* fluxes, as defined in [Objects and Sources](objects_sources.html).
 
-Since each source brightness is measured for a specific optical filter, there may be 
-several lightcurves for a given object, for example the g-lightcurve and r-lightcurve will
-be derived from the detections in the g filter and r filter respectively.
+Since each source brightness is measured for a specific optical filter, there may be several lightcurves for a given object, for example the g-lightcurve and r-lightcurve will be derived from the detections in the g filter and r filter respectively.
 
-It is only when an object is more than 5 sigma over the reference imagery that a transient alert is sent out, 
-this is the "unforced" photometry plotted in the object pages. Other brightness measurements are also computed 
-from the imagery, the "forced" photometry at the location of the transient. In each case, what is measured is 
-a "difference" brightness from the reference image, which can be positive or negative.
-More information about forced photometry and ZTF can be found <a href=https://arxiv.org/abs/2305.16279>here</a>.
+When a source is detected at a significance of 5-sigma or more in the difference image then an alert is issued. This is defined as 5-sigma above the noise in the difference image, within a point-spread-function (PSF) aperture. 
+This is the "unforced" photometry plotted in the object pages. Another important measurement computed from
+the difference image is called the "forced" photometry. After an object has been identified then a photometric measurement (based on a PSF model) is forced at the position of the object on all images, irrespective of whether or not the object exists at 5-sigma significance. What is being measured is a "difference" in flux compared to the reference image. This flux can be positive or negative and can be simply calibrated in a physical flux unit such as a
+nanoJansky.  More information about forced photometry and ZTF can be found 
+[here](https://arxiv.org/abs/2305.16279).
 
-The nature of the lightcurve informs us of the underlying astrophysics. Variable stars can be characterised
-by the shape of their lightcurves, and explosive transients such as supernovae can be distinguished by the 
-rise and fall rates of their lightcurves.
+The nature of the lightcurve informs us of the underlying astrophysics. Variable stars can be characterised by the shape and periodicity of their lightcurves, and explosive transients such as supernovae can be distinguished by the rise and fall rates of their lightcurves.

--- a/webserver/lasair/apps/object/utils.py
+++ b/webserver/lasair/apps/object/utils.py
@@ -150,12 +150,12 @@ def object_difference_lightcurve(
         plot_bgcolor='white',
         paper_bgcolor='white',
         height=650,
-        margin_t=100,
+        margin_t=0,
         margin_r=1,
         legend=dict(
             orientation="h",
             yanchor="top",
-            y=-0.3,
+            y=-0.2,
             xanchor="left",
             x=0
         ),
@@ -181,7 +181,7 @@ def object_difference_lightcurve(
 
     htmlLightcurve = fig.to_html(
         config={
-            'displayModeBar': True,
+            'displayModeBar': False,
             'displaylogo': False,
             'modeBarButtonsToRemove': ['select2d', 'lasso2d'],
             'toImageButtonOptions': {'filename': objectData["objectId"] + "_lasair_lc"},
@@ -249,11 +249,12 @@ def object_difference_lightcurve_forcedphot(
                 go.Scatter(
                     x=data["mjd"],
                     y=data["microjansky"],
-                    customdata=np.stack((data['utc'], data['microjansky'], data['microjansky']), axis=-1),
+                    customdata=np.stack((data['utc'], data['microjansky'], data['microjanskyerr']), axis=-1),
                     error_y=error_y,
                     error_y_thickness=0.7,
                     error_y_color=data["bcolor"].values[0],
                     mode='markers',
+                    showlegend=False,
                     marker_size=data["marker_size"].values[0],
                     marker_color=data["marker_color"].values[0],
                     marker_symbol=data["marker_symbol"].values[0],
@@ -264,7 +265,7 @@ def object_difference_lightcurve_forcedphot(
                     hovertemplate="<b>" + data["name"] + "</b><br>" +
                     "MJD: %{x:.2f}<br>" +
                     "UTC: %{customdata[0]}<br>" +
-                    "Flux: %{customdata[1]:.2f} μJy %{customdata[2]:.2f}" +
+                    "Flux: %{customdata[1]:.2f} ± %{customdata[2]:.2f} μJy" +
                     "<extra></extra>",
                 ),
                 secondary_y=False
@@ -283,7 +284,7 @@ def object_difference_lightcurve_forcedphot(
 
     fig.update_xaxes(range=[mjdMin, mjdMax], tickformat='d', tickangle=-55, tickfont_size=14, showline=True, linewidth=1.5, linecolor='#1F2937',
                      gridcolor='#F0F0F0', gridwidth=1,
-                     zeroline=True, zerolinewidth=1.5, zerolinecolor='#1F2937', ticks='inside', title="MJD", title_font_size=16)
+                     zeroline=True, zerolinewidth=1.5, zerolinecolor='#1F2937', ticks='inside', title_font_size=16)
     fig.update_layout(xaxis2={'range': [utcMin, utcMax],
                               'showgrid': False,
                               'anchor': 'y',
@@ -305,9 +306,9 @@ def object_difference_lightcurve_forcedphot(
         linecolor='#1F2937',
         gridcolor='#F0F0F0',
         gridwidth=1,
-        zeroline=False,
+        zeroline=True,
         zerolinewidth=3.0,
-        zerolinecolor='rgba(60, 60, 60, 0.4)',
+        zerolinecolor='rgba(60, 60, 60, 0.8)',
         mirror=True,
         ticks='inside',
         title="Difference Flux (μJy)",
@@ -315,14 +316,13 @@ def object_difference_lightcurve_forcedphot(
         secondary_y=False
     )
 
-    fig.add_hrect(y0=-100, y1=0, line_width=0, fillcolor="black", opacity=0.1)
-
     # UPDATE PLOT LAYOUT
     fig.update_layout(
         plot_bgcolor='white',
         paper_bgcolor='white',
         height=650,
-        margin_t=100,
+        margin_t=0,
+        margin_b=0,
         margin_r=1,
         legend=dict(
             orientation="h",
@@ -353,7 +353,7 @@ def object_difference_lightcurve_forcedphot(
 
     htmlLightcurve = fig.to_html(
         config={
-            'displayModeBar': True,
+            'displayModeBar': False,
             'displaylogo': False,
             'modeBarButtonsToRemove': ['select2d', 'lasso2d'],
             'toImageButtonOptions': {'filename': objectData["objectId"] + "_lasair_lc"},

--- a/webserver/lasair/apps/object/utils.py
+++ b/webserver/lasair/apps/object/utils.py
@@ -210,7 +210,7 @@ def object_difference_lightcurve_forcedphot(
     forcedDF, unforcedDF, mergedDF = convert_objectdata_to_dataframes(objectData)
 
     if forcedDF is None:
-        return None
+        return None, None
 
     # FILTER DATA FRAME
     forcedDF["marker_color"] = "#268bd2"
@@ -475,7 +475,12 @@ def convert_objectdata_to_dataframes(
                                ascending=[True], inplace=True)
 
     # MATCH THE FORCED AND UNFORCED TABLES
-    mergedDF = pd.merge(unforcedDF, forcedDF[['microjansky', 'microjanskyerr', 'jd', 'fid']], how='left', on=['jd', 'fid'])
+    if forcedDF is not None:
+        mergedDF = pd.merge(unforcedDF, forcedDF[['microjansky', 'microjanskyerr', 'jd', 'fid']], how='left', on=['jd', 'fid'])
+    else:
+        mergedDF = unforcedDF
+        mergedDF['microjansky'] = np.nan
+        mergedDF['microjanskyerr'] = np.nan
     mergedDF = mergedDF.replace({np.nan: None})
     mergedDF.sort_values(['mjd'], ascending=[False], inplace=True)
 

--- a/webserver/lasair/apps/object/utils.py
+++ b/webserver/lasair/apps/object/utils.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from astropy.time import Time
 import plotly.graph_objects as go
 import math
 import numpy as np
@@ -21,39 +22,29 @@ def object_difference_lightcurve(
     ```
     """
     # CREATE DATA FRAME FOR LC
-    df = pd.DataFrame(objectData["candidates"])
-    from astropy.time import Time
-    mjds = Time(df['mjd'], format='mjd')
-    df['utc'] = mjds.iso
-    df['utc'] = pd.to_datetime(df['utc']).dt.strftime('%Y-%m-%d %H:%M:%S')
+    forcedDF, unforcedDF = convert_objectdata_to_dataframes(objectData)
 
     # FILTER DATA FRAME
-    df["marker_color"] = "#268bd2"
-    df["marker_symbol"] = "arrow-bar-down-open"
-    df["marker_size"] = 8
-    df["marker_opacity"] = 0.6
-    df["name"] = "anon"
+    unforcedDF["marker_color"] = "#268bd2"
+    unforcedDF["marker_symbol"] = "arrow-bar-down-open"
+    unforcedDF["marker_size"] = 8
+    unforcedDF["marker_opacity"] = 0.6
+    unforcedDF["name"] = "anon"
     symbol_sequence = ["arrow-bar-down-open", "circle"]
-    df.loc[(df['fid'] == 1), "marker_color"] = "#859900"
-    df.loc[(df['fid'] == 1), "bcolor"] = "#606e03"
-    df.loc[(df['fid'] == 2), "marker_color"] = "#dc322f"
-    df.loc[(df['fid'] == 2), "bcolor"] = "#b01f1c"
-    df.loc[(df['candid'] > 0), "marker_symbol"] = "circle-open"
-    df.loc[((df['candid'] > 0) & (df['isdiffpos'].isin([1, 't']))), "marker_symbol"] = "circle"
-    df.loc[(df['candid'] > 0), "marker_size"] = 10
-
-    # ADD FLUX
-    df["flux"] = 10**((23.9 - df["magpsf"]) / 2.5)
-    df["fluxerr"] = (10**((23.9 - (df["magpsf"] - df["sigmapsf"])) / 2.5) - 10**((23.9 - (df["magpsf"] + df["sigmapsf"])) / 2.5)) / 2
+    unforcedDF.loc[(unforcedDF['fid'] == 1), "marker_color"] = "#859900"
+    unforcedDF.loc[(unforcedDF['fid'] == 1), "bcolor"] = "#606e03"
+    unforcedDF.loc[(unforcedDF['fid'] == 2), "marker_color"] = "#dc322f"
+    unforcedDF.loc[(unforcedDF['fid'] == 2), "bcolor"] = "#b01f1c"
+    unforcedDF.loc[(unforcedDF['candid'] > 0), "marker_symbol"] = "circle-open"
+    unforcedDF.loc[((unforcedDF['candid'] > 0) & (unforcedDF['isdiffpos'].isin([1, 't']))), "marker_symbol"] = "circle"
+    unforcedDF.loc[(unforcedDF['candid'] > 0), "marker_size"] = 10
 
     # SORT BY COLUMN NAME
-    df.sort_values(['mjd'],
-                   ascending=[True], inplace=True)
-    discovery = df.loc[(df['candid'] > 0)].head(1)
+    discovery = unforcedDF.loc[(unforcedDF['candid'] > 0)].head(1)
 
     # GENERATE THE DATASETS
-    gBandData = df.loc[(df['fid'] == 1)]
-    rBandData = df.loc[(df['fid'] == 2)]
+    gBandData = unforcedDF.loc[(unforcedDF['fid'] == 1)]
+    rBandData = unforcedDF.loc[(unforcedDF['fid'] == 2)]
     rBandDetections = rBandData.loc[(rBandData['candid'] > 0)]
     rBandNonDetections = rBandData.loc[~(rBandData['candid'] > 0)]
     rBandNonDetections["name"] = "r-band limiting mag"
@@ -79,7 +70,7 @@ def object_difference_lightcurve(
         if len(data.index):
             if data['candid'].values[0] > 0:
                 dataType = "Diff Mag"
-                error_y = {'type': 'data', 'array': data["fluxerr"]}
+                error_y = {'type': 'data', 'array': data["sigmapsf"]}
             else:
                 error_y = None
                 dataType = "Limiting Mag"
@@ -87,7 +78,7 @@ def object_difference_lightcurve(
 
                 go.Scatter(
                     x=data["mjd"],
-                    y=data["flux"],
+                    y=data["magpsf"],
                     customdata=np.stack((data['utc'], data['magpsf'], data['sigmapsf']), axis=-1),
                     error_y=error_y,
                     error_y_thickness=0.7,
@@ -103,22 +94,10 @@ def object_difference_lightcurve(
                     hovertemplate="<b>" + data["name"] + "</b><br>" +
                     "MJD: %{x:.2f}<br>" +
                     "UTC: %{customdata[0]}<br>" +
-                    "Flux: %{y} μJy<br>" +
                     "Magnitude: %{customdata[1]:.2f} ± %{customdata[2]:.2f}" +
                     "<extra></extra>",
                 ),
                 secondary_y=False
-            )
-            fig.add_trace(
-
-                go.Scatter(
-                    x=data["mjd"],
-                    y=data["flux"],
-                    showlegend=False,
-                    opacity=0,
-                    hoverinfo='skip',
-                ),
-                secondary_y=True
             )
             fig.add_traces(
                 go.Scatter(x=data["utc"],
@@ -129,16 +108,7 @@ def object_difference_lightcurve(
                            xaxis="x2"))
 
     # DETERMINE SENSIBLE X-AXIS LIMITS
-    mjdMin = df.loc[(df['candid'] > 0), "mjd"].min()
-    mjdMax = df.loc[(df['candid'] > 0), "mjd"].max()
-    mjdRange = mjdMax - mjdMin
-    if mjdRange < 5:
-        mjdRange = 5
-    mjdMin -= 2 + mjdRange * 0.05
-    mjdMax += 2 + mjdRange * 0.05
-
-    utcMin = Time(mjdMin, format='mjd').iso
-    utcMax = Time(mjdMax, format='mjd').iso
+    mjdMin, mjdMax, utcMin, utcMax, fluxMin, fluxMax, magMin, magMax = get_default_axis_ranges(forcedDF, unforcedDF)
 
     fig.update_xaxes(range=[mjdMin, mjdMax], tickformat='d', tickangle=-55, tickfont_size=14, showline=True, linewidth=1.5, linecolor='#1F2937',
                      gridcolor='#F0F0F0', gridwidth=1,
@@ -154,25 +124,13 @@ def object_difference_lightcurve(
                               'linewidth': 1.5,
                               'linecolor': '#1F2937'})
 
-    # DETERMINE SENSIBLE Y-AXIS LIMITS
-    ymax = df.loc[(df['candid'] > 0), "flux"].max()
-    ymin = 1e-10
-    yrange = ymax - ymin
-    if yrange < 50:
-        yrange = 50
-    ymax += (yrange * 0.1)
-    yMagMin = -2.5 * math.log10(ymax) + 23.9
-    yMagMax = -2.5 * math.log10(ymin) + 23.9
-
-    # yFluxMax = 10**((23.9 - ymin) / 2.5)
-    # yFluxMin = 10**((23.9 - ymax) / 2.5)
-
     fig.update_yaxes(
-        range=[ymin, ymax],
+        range=[magMax, magMin],
         tickformat='.1f',
         tickfont_size=14,
         ticksuffix=" ",
         showline=True,
+        showgrid=True,
         linewidth=1.5,
         linecolor='#1F2937',
         gridcolor='#F0F0F0',
@@ -182,47 +140,9 @@ def object_difference_lightcurve(
         zerolinecolor='#1F2937',
         mirror=True,
         ticks='inside',
-        title="Difference Flux (μJy)",
-        title_font_size=16,
-        secondary_y=False
-    )
-
-    magLabels = [21.0, 20.0, 19.5, 19.0, 18.5,
-                 18.0, 17.5, 17.0, 16.5, 16.0, 15.5, 15.0]
-    if yMagMin < 14:
-        magLabels = [20.0, 16.0, 15.0, 14.0,
-                     13.0, 12.5, 12.0, 11.5, 11.0]
-    elif yMagMin < 17:
-        magLabels = [20., 19.,
-                     18.0, 17.0, 16.5, 16.0, 15.5, 15.0]
-    elif yMagMin < 18:
-        magLabels = [20., 19.5, 19.0, 18.5,
-                     18.0, 17.5, 17.0, 16.5, 16.0, 15.5, 15.0]
-    magFluxes = [10**((23.9 - m) / 2.5) for m in magLabels]
-    magLabels = [f"{m:0.1f}" for m in magLabels]
-
-    fig.update_yaxes(
-        dict(
-            tickmode='array',
-            tickvals=magFluxes,
-            ticktext=magLabels
-        ),
-        range=[ymin, ymax],
-        tickformat='.1f',
-        tickfont_size=14,
-        ticksuffix=" ",
-        showline=True,
-        showgrid=False,
-        linewidth=1.5,
-        linecolor='#1F2937',
-        zeroline=True,
-        zerolinewidth=1.5,
-        zerolinecolor='#1F2937',
-        ticks='inside',
         title="Difference Magnitude",
         title_font_size=16,
-        secondary_y=True,
-
+        secondary_y=False,
     )
 
     # UPDATE PLOT LAYOUT
@@ -248,7 +168,7 @@ def object_difference_lightcurve(
 
     fig.add_trace(go.Scatter(
         x=discovery["mjd"],
-        y=[5],
+        y=[magMax - 0.05],
         mode="markers+text",
         marker_symbol="triangle-up",
         marker_opacity=1,
@@ -269,6 +189,278 @@ def object_difference_lightcurve(
         })
 
     return htmlLightcurve
+
+
+def object_difference_lightcurve_forcedphot(
+    objectData
+):
+    """*Generate the Plotly HTML lightcurve for the object force photometry*
+
+    **Key Arguments:**
+
+    - ``objectData`` -- a json object containing lightcurve data (and more)
+
+    **Usage:**
+
+    ```python
+    from lasair.apps.objects.utils import object_difference_lightcurve_forcedphot
+    htmlLightcurve = object_difference_lightcurve_forcedphot(data)
+    ```
+    """
+    forcedDF, unforcedDF = convert_objectdata_to_dataframes(objectData)
+
+    if forcedDF is None:
+        return None
+
+    # FILTER DATA FRAME
+    forcedDF["marker_color"] = "#268bd2"
+    forcedDF["marker_symbol"] = "arrow-bar-down-open"
+    forcedDF["marker_size"] = 8
+    forcedDF["marker_opacity"] = 0.6
+    forcedDF["name"] = "anon"
+    symbol_sequence = ["arrow-bar-down-open", "circle"]
+    forcedDF.loc[(forcedDF['fid'] == 1), "marker_color"] = "#859900"
+    forcedDF.loc[(forcedDF['fid'] == 1), "bcolor"] = "#606e03"
+    forcedDF.loc[(forcedDF['fid'] == 2), "marker_color"] = "#dc322f"
+    forcedDF.loc[(forcedDF['fid'] == 2), "bcolor"] = "#b01f1c"
+    forcedDF["marker_symbol"] = "circle"
+    forcedDF["marker_size"] = 10
+
+    discovery = unforcedDF.loc[(unforcedDF['candid'] > 0)].head(1)
+
+    # GENERATE THE DATASETS
+    gBandDetections = forcedDF.loc[(forcedDF['fid'] == 1)]
+    rBandDetections = forcedDF.loc[(forcedDF['fid'] == 2)]
+    gBandDetections["name"] = "g-band detection"
+    rBandDetections["name"] = "r-band detection"
+    allDataSets = [gBandDetections, rBandDetections]
+
+    # START TO PLOT
+    from plotly.subplots import make_subplots
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
+    # fig = go.Figure()
+
+    for data in allDataSets:
+        if len(data.index):
+            dataType = "Diff Flux"
+            error_y = {'type': 'data', 'array': data["forcediffimfluxunc"]}
+            fig.add_trace(
+
+                go.Scatter(
+                    x=data["mjd"],
+                    y=data["forcediffimflux"],
+                    customdata=np.stack((data['utc'], data['forcediffimflux'], data['forcediffimfluxunc']), axis=-1),
+                    error_y=error_y,
+                    error_y_thickness=0.7,
+                    error_y_color=data["bcolor"].values[0],
+                    mode='markers',
+                    marker_size=data["marker_size"].values[0],
+                    marker_color=data["marker_color"].values[0],
+                    marker_symbol=data["marker_symbol"].values[0],
+                    marker_line_color=data["bcolor"].values[0],
+                    marker_line_width=1.5,
+                    marker_opacity=data["marker_opacity"].values[0],
+                    name=data["name"].values[0],
+                    hovertemplate="<b>" + data["name"] + "</b><br>" +
+                    "MJD: %{x:.2f}<br>" +
+                    "UTC: %{customdata[0]}<br>" +
+                    "Flux: %{customdata[1]:.2f} DN %{customdata[2]:.2f}" +
+                    "<extra></extra>",
+                ),
+                secondary_y=False
+            )
+
+            fig.add_traces(
+                go.Scatter(x=data["utc"],
+                           y=data["forcediffimflux"],
+                           showlegend=False,
+                           opacity=0,
+                           hoverinfo='skip',
+                           xaxis="x2"))
+
+    # DETERMINE SENSIBLE X-AXIS LIMITS
+    mjdMin, mjdMax, utcMin, utcMax, fluxMin, fluxMax, magMin, magMax = get_default_axis_ranges(forcedDF, unforcedDF)
+
+    fig.update_xaxes(range=[mjdMin, mjdMax], tickformat='d', tickangle=-55, tickfont_size=14, showline=True, linewidth=1.5, linecolor='#1F2937',
+                     gridcolor='#F0F0F0', gridwidth=1,
+                     zeroline=True, zerolinewidth=1.5, zerolinecolor='#1F2937', ticks='inside', title="MJD", title_font_size=16)
+    fig.update_layout(xaxis2={'range': [utcMin, utcMax],
+                              'showgrid': False,
+                              'anchor': 'y',
+                              'overlaying': 'x',
+                              'side': 'top',
+                              'tickangle': -55,
+                              'tickfont_size': 14,
+                              'showline': True,
+                              'linewidth': 1.5,
+                              'linecolor': '#1F2937'})
+
+    fig.update_yaxes(
+        range=[fluxMin, fluxMax],
+        tickformat='.1f',
+        tickfont_size=14,
+        ticksuffix=" ",
+        showline=True,
+        linewidth=1.5,
+        linecolor='#1F2937',
+        gridcolor='#F0F0F0',
+        gridwidth=1,
+        zeroline=False,
+        zerolinewidth=1.5,
+        zerolinecolor='#1F2937',
+        mirror=True,
+        ticks='inside',
+        title="Difference Flux (DN)",
+        title_font_size=16,
+        secondary_y=False
+    )
+
+    # UPDATE PLOT LAYOUT
+    fig.update_layout(
+        plot_bgcolor='white',
+        paper_bgcolor='white',
+        height=650,
+        margin_t=100,
+        margin_r=1,
+        legend=dict(
+            orientation="h",
+            yanchor="top",
+            y=-0.3,
+            xanchor="left",
+            x=0
+        ),
+        hoverlabel=dict(
+            font_color="white",
+            bgcolor="#1F2937",
+            font_size=14,
+        )
+    )
+
+    fig.add_trace(go.Scatter(
+        x=discovery["mjd"],
+        y=[10],
+        mode="markers+text",
+        marker_symbol="triangle-up",
+        marker_opacity=1,
+        marker_color="#1F2937",
+        marker_size=8,
+        showlegend=False,
+        text=["Discovery Epoch"],
+        textposition="middle right"
+    ))
+
+    htmlLightcurve = fig.to_html(
+        config={
+            'displayModeBar': True,
+            'displaylogo': False,
+            'modeBarButtonsToRemove': ['select2d', 'lasso2d'],
+            'toImageButtonOptions': {'filename': objectData["objectId"] + "_lasair_lc"},
+            'responsive': True
+        })
+
+    return htmlLightcurve
+
+
+def get_default_axis_ranges(
+        forcedDF,
+        unforcedDF):
+    """*get the default x and y-axis ranges for the lightcurve plots*
+
+    **Key Arguments:**
+
+    - `forcedDF` -- forced photometry dataframe
+    - `unforcedDF` -- unforced photometry dataframe    
+    """
+
+    if forcedDF is not None:
+        mjdMin = forcedDF.loc[((forcedDF['forcediffimflux'] > 50) & (forcedDF['forcediffimfluxunc'] < 50)), "mjd"].min()
+        mjdMax = forcedDF.loc[((forcedDF['forcediffimflux'] > 50) & (forcedDF['forcediffimfluxunc'] < 50)), "mjd"].max()
+    else:
+        mjdMin = unforcedDF.loc[(unforcedDF['candid'] > 0), "mjd"].min()
+        mjdMax = unforcedDF.loc[(unforcedDF['candid'] > 0), "mjd"].max()
+
+    # SORT BY COLUMN NAME
+    discovery = unforcedDF.loc[(unforcedDF['candid'] > 0)].head(1)
+    if mjdMin > discovery["mjd"].min():
+        mjdMin = discovery["mjd"].min()
+
+    mjdRange = mjdMax - mjdMin
+    if mjdRange < 5:
+        mjdRange = 5
+    mjdMin -= 4 + mjdRange * 0.05
+    mjdMax += 2 + mjdRange * 0.05
+
+    utcMin = Time(mjdMin, format='mjd').iso
+    utcMax = Time(mjdMax, format='mjd').iso
+
+    # DETERMINE SENSIBLE Y-AXIS LIMITS
+    if forcedDF is not None:
+        fluxMax = forcedDF.loc[((forcedDF['mjd'] > mjdMin) & (forcedDF['mjd'] < mjdMax)), "forcediffimflux"] + forcedDF.loc[((forcedDF['mjd'] > mjdMin) & (forcedDF['mjd'] < mjdMax)), "forcediffimfluxunc"]
+        fluxMax = fluxMax.max()
+        fluxMin = forcedDF.loc[((forcedDF['mjd'] > mjdMin) & (forcedDF['mjd'] < mjdMax)), "forcediffimflux"] - forcedDF.loc[((forcedDF['mjd'] > mjdMin) & (forcedDF['mjd'] < mjdMax)), "forcediffimfluxunc"]
+        fluxMin = fluxMin.min()
+
+        yrange = fluxMax - fluxMin
+        if yrange < 50:
+            yrange = 50
+        fluxMax += (yrange * 0.1)
+        fluxMin -= (yrange * 0.1)
+
+        if fluxMin > 0:
+            fluxMin = 0
+    else:
+        fluxMin, fluxMax = None, None
+
+    # DETERMINE SENSIBLE Y-AXIS LIMITS
+    unforcedDF["tmpSigmapsf"] = 0
+
+    unforcedDF.loc[(unforcedDF['sigmapsf'] > 0), "tmpSigmapsf"] = unforcedDF.loc[(unforcedDF['sigmapsf'] > 0), "sigmapsf"]
+    unforcedDF["tmpSigmapsf"]
+    unforcedDF.loc[((unforcedDF['mjd'] > mjdMin) & (unforcedDF['mjd'] < mjdMax)), "sigmapsf"] = 0
+    magMax = unforcedDF.loc[((unforcedDF['mjd'] > mjdMin) & (unforcedDF['mjd'] < mjdMax)), "magpsf"] + unforcedDF.loc[((unforcedDF['mjd'] > mjdMin) & (unforcedDF['mjd'] < mjdMax)), "tmpSigmapsf"]
+    magMax = magMax.max()
+    magMin = unforcedDF.loc[((unforcedDF['mjd'] > mjdMin) & (unforcedDF['mjd'] < mjdMax)), "magpsf"] - unforcedDF.loc[((unforcedDF['mjd'] > mjdMin) & (unforcedDF['mjd'] < mjdMax)), "tmpSigmapsf"]
+    magMin = magMin.min()
+
+    yrange = magMax - magMin
+    if yrange < 3:
+        yrange = 3
+    magMax += (yrange * 0.1)
+    magMin -= (yrange * 0.1)
+
+    return mjdMin, mjdMax, utcMin, utcMax, fluxMin, fluxMax, magMin, magMax
+
+
+def convert_objectdata_to_dataframes(
+        objectData):
+    """*return a forced photometry and unforce photometry dataframe from the objectdata*
+
+    **Key Arguments:**
+
+    - `objectData` -- the object data (forced and unforced)      
+    """
+    forcedDF, unforcedDF = None, None
+
+    # CREATE DATA FRAME FOR LC
+    if len(objectData["forcedphot"]):
+        forcedDF = pd.DataFrame(objectData["forcedphot"])
+        mjds = Time(forcedDF['mjd'], format='mjd')
+        forcedDF['utc'] = mjds.iso
+        forcedDF['utc'] = pd.to_datetime(forcedDF['utc']).dt.strftime('%Y-%m-%d %H:%M:%S')
+        # SORT BY COLUMN NAME
+        forcedDF.sort_values(['mjd'],
+                             ascending=[True], inplace=True)
+
+    # NORMAL UNFORCED PHOTO
+    if len(objectData["candidates"]):
+        unforcedDF = pd.DataFrame(objectData["candidates"])
+        mjds2 = Time(unforcedDF['mjd'], format='mjd')
+        unforcedDF['utc'] = mjds2.iso
+        unforcedDF['utc'] = pd.to_datetime(unforcedDF['utc']).dt.strftime('%Y-%m-%d %H:%M:%S')
+        unforcedDF.sort_values(['mjd'],
+                               ascending=[True], inplace=True)
+
+    return forcedDF, unforcedDF
 
 # use the tab-trigger below for new function
 # xt-def-function

--- a/webserver/lasair/apps/object/views.py
+++ b/webserver/lasair/apps/object/views.py
@@ -55,10 +55,19 @@ def object_detail(request, objectId):
     if 'sherlock' in data2:
         data2.pop('sherlock')
 
+    lightcurveHtml, mergedDF = object_difference_lightcurve(data)
+    fplightcurveHtml, mergedDF = object_difference_lightcurve_forcedphot(data)
+    lcData = mergedDF.to_dict('records')
+
+    for c in lcData:
+        print()
+        print(c)
+
     return render(request, 'object/object_detail.html', {
         'data': data,
         'json_data': json.dumps(data2),
         'authenticated': request.user.is_authenticated,
-        'lightcurveHtml': object_difference_lightcurve(data),
-        'fplightcurveHtml': object_difference_lightcurve_forcedphot(data)
+        'lightcurveHtml': lightcurveHtml,
+        'fplightcurveHtml': fplightcurveHtml,
+        'lcData': lcData
     })

--- a/webserver/lasair/apps/object/views.py
+++ b/webserver/lasair/apps/object/views.py
@@ -16,7 +16,7 @@ import os
 import sys
 from astropy.time import Time
 from lasair.utils import mjd_now, ecliptic, rasex, decsex, objjson
-from .utils import object_difference_lightcurve
+from .utils import object_difference_lightcurve, object_difference_lightcurve_forcedphot
 sys.path.append('../common')
 
 
@@ -59,5 +59,6 @@ def object_detail(request, objectId):
         'data': data,
         'json_data': json.dumps(data2),
         'authenticated': request.user.is_authenticated,
-        'lightcurveHtml': object_difference_lightcurve(data)
+        'lightcurveHtml': object_difference_lightcurve(data),
+        'fplightcurveHtml': object_difference_lightcurve_forcedphot(data)
     })

--- a/webserver/lasair/apps/object/views.py
+++ b/webserver/lasair/apps/object/views.py
@@ -57,11 +57,10 @@ def object_detail(request, objectId):
 
     lightcurveHtml, mergedDF = object_difference_lightcurve(data)
     fplightcurveHtml, mergedDF = object_difference_lightcurve_forcedphot(data)
-    lcData = mergedDF.to_dict('records')
-
-    for c in lcData:
-        print()
-        print(c)
+    if mergedDF is not None:
+        lcData = mergedDF.to_dict('records')
+    else:
+        lcData = data["candidates"]
 
     return render(request, 'object/object_detail.html', {
         'data': data,

--- a/webserver/lasair/lightcurves.py
+++ b/webserver/lasair/lightcurves.py
@@ -77,7 +77,7 @@ class forcedphot_lightcurve_fetcher(lightcurve_fetcher):
             if full:
                 query = "SELECT * "
             else:
-                query = "SELECT objectid, jd, ranr, decnr, fid, forcediffimflux, forcediffimfluxunc "
+                query = "SELECT objectid, jd, ranr, decnr, fid, forcediffimflux, forcediffimfluxunc, magzpsci "
             query += "from forcedphot where objectId = '%s'" % objectId
             ret = self.session.execute(query)
             candidates = [c for c in ret]

--- a/webserver/lasair/lightcurves.py
+++ b/webserver/lasair/lightcurves.py
@@ -51,7 +51,7 @@ class lightcurve_fetcher():
                 candidates.append(cand)
             return candidates
         else:
-#            store = objectStore(suffix='json', fileroot=self.fileroot, double=True)
+            #            store = objectStore(suffix='json', fileroot=self.fileroot, double=True)
             store = objectStore(suffix='json', fileroot=self.fileroot)
             lc = store.getObject(objectId)
 
@@ -63,12 +63,25 @@ class lightcurve_fetcher():
                 candidates = candlist['candidates']
                 return candidates
             except:
-                print(lc)
                 raise lightcurve_fetcher_error('Cannot parse json for object %s' % objectId)
 
     def close(self):
         if self.session:
             self.cluster.shutdown()
+
+
+class forcedphot_lightcurve_fetcher(lightcurve_fetcher):
+
+    def fetch(self, objectId, full=False):
+        if self.using_cassandra:
+            if full:
+                query = "SELECT * "
+            else:
+                query = "SELECT objectid, jd, ranr, decnr, fid, forcediffimflux, forcediffimfluxunc "
+            query += "from forcedphot where objectId = '%s'" % objectId
+            ret = self.session.execute(query)
+            candidates = [c for c in ret]
+            return candidates
 
 
 if __name__ == "__main__":

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -47,9 +47,9 @@
                         <th>MJD</th>
                         <th>UTC</th>
                         <th>Filter</th>
-                        <th>magpsf</th>
-                        <th>difference flux status</th>
-                        <th>flux (μJy)</th>
+                        <th>unforced mag</th>
+                        <th>unforced mag status</th>
+                        <th>forced flux (μJy)</th>
                         <th>images</th>
                         <th>alert packet</th>
                     </tr></thead>
@@ -91,11 +91,11 @@
                     <tr>
                         <th>MJD</th>
                         <th>filter</th>
-                        <th>magpsf</th>
-                        <th>magpsf_error</th>
-                        <th>microjansky</th>
-                        <th>microjansky_error</th>
-                        <th>flux_status</th>
+                        <th>unforced_mag</th>
+                        <th>unforced_mag_error</th>
+                        <th>unforced_mag_status</th>
+                        <th>forced_ujy</th>
+                        <th>forced_ujy_error</th>
                     </tr></thead>
                 <tbody>
                     {% for cand in lcData %}
@@ -105,10 +105,10 @@
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% else %}r{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{{ cand.magpsf|floatformat:3 }}</td>
                             <td>{% if cand.candid %}{{ cand.sigmapsf|floatformat:3 }}{% endif %}</td>
+                            <td>{% if cand.candid %}{{ cand.isdiffpos|replace:"t|positive"|replace:"f|negative" }}{% else %}<font color="gray" size=-2>limit</font>{% endif %}</td>
                             <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:1 }}{% endif %}</td>
                             <td>{% if cand.microjanskyerr %}{{ cand.microjanskyerr|floatformat:1 }}{% endif %}</td>
 
-                            <td>{% if cand.candid %}{{ cand.isdiffpos|replace:"t|positive"|replace:"f|negative" }}{% else %}<font color="gray" size=-2>limit</font>{% endif %}</td>
 
 
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -49,11 +49,12 @@
                         <th>Filter</th>
                         <th>magpsf</th>
                         <th>difference flux status</th>
+                        <th>flux (μJy)</th>
                         <th>images</th>
                         <th>alert packet</th>
                     </tr></thead>
                 <tbody>
-                    {% for cand in data.candidates %}
+                    {% for cand in lcData %}
 
                         <tr>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{{ cand.mjd|floatformat:6 }}{% if not cand.candid %}</font>{% endif %}</td>
@@ -67,11 +68,12 @@
                             {% endif %}</td>
 
 
+                            <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:3 }} &plusmn; {{ cand.microjanskyerr|floatformat:3 }}{% endif %}</td>
 
                             <td>{% if cand.candid > 0 %}
-				    {% if cand.image_urls.Science %}<a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutScience");'><small>target</small></a> {% endif %}
-				    {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutTemplate");'><small>ref</small></a> {% endif %}
-				    {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutDifference");'><small>diff</small></a> {% endif %}
+                                {% if cand.image_urls.Science %}<a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutScience");'><small>target</small></a> {% endif %}
+                                {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutTemplate");'><small>ref</small></a> {% endif %}
+                                {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutDifference");'><small>diff</small></a> {% endif %}
                             {% endif %}</td>
 
                             <td> {% if cand.candid %}<a tabindex="0" class="disable"  data-bs-html="true"  data-bs-container="body" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-placement="top" data-bs-content='<pre><code>{{cand.json}}</code></pre>'>data</a>{% endif %}</td>
@@ -91,16 +93,20 @@
                         <th>filter</th>
                         <th>magpsf</th>
                         <th>magpsf_error</th>
+                        <th>microjansky</th>
+                        <th>microjansky_error</th>
                         <th>flux_status</th>
                     </tr></thead>
                 <tbody>
-                    {% for cand in data.candidates %}
+                    {% for cand in lcData %}
 
                         <tr>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{{ cand.mjd|floatformat:6 }}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% else %}r{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{{ cand.magpsf|floatformat:3 }}</td>
                             <td>{% if cand.candid %}{{ cand.sigmapsf|floatformat:3 }}{% endif %}</td>
+                            <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:2 }}{% endif %}</td>
+                            <td>{% if cand.microjanskyerr %}{{ cand.microjanskyerr|floatformat:2 }}{% endif %}</td>
 
                             <td>{% if cand.candid %}{{ cand.isdiffpos|replace:"t|positive"|replace:"f|negative" }}{% else %}<font color="gray" size=-2>limit</font>{% endif %}</td>
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -68,7 +68,7 @@
                             {% endif %}</td>
 
 
-                            <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:3 }} &plusmn; {{ cand.microjanskyerr|floatformat:3 }}{% endif %}</td>
+                            <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:1 }} &plusmn; {{ cand.microjanskyerr|floatformat:1 }}{% endif %}</td>
 
                             <td>{% if cand.candid > 0 %}
                                 {% if cand.image_urls.Science %}<a href='javascript:JS9Popout("/fits/{{ cand.imjd }}/{{ cand.candid }}_cutoutScience");'><small>target</small></a> {% endif %}
@@ -105,8 +105,8 @@
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% else %}r{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{{ cand.magpsf|floatformat:3 }}</td>
                             <td>{% if cand.candid %}{{ cand.sigmapsf|floatformat:3 }}{% endif %}</td>
-                            <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:2 }}{% endif %}</td>
-                            <td>{% if cand.microjanskyerr %}{{ cand.microjanskyerr|floatformat:2 }}{% endif %}</td>
+                            <td>{% if cand.microjansky %}{{ cand.microjansky|floatformat:1 }}{% endif %}</td>
+                            <td>{% if cand.microjanskyerr %}{{ cand.microjanskyerr|floatformat:1 }}{% endif %}</td>
 
                             <td>{% if cand.candid %}{{ cand.isdiffpos|replace:"t|positive"|replace:"f|negative" }}{% else %}<font color="gray" size=-2>limit</font>{% endif %}</td>
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_lightcurve.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_lightcurve.html
@@ -37,10 +37,10 @@
         </div>
     </div>
     {% if fplightcurveHtml %}
-        <div class="card-body">
+        <div class="card-body  pb-0  pt-0">
 
             <div class="d-flex justify-content-center ms-2">
-                <h4 class="h5 text-gray-400 mb-0 ps-2">Forced Photometry{% include "includes/info_tooltip.html" with info="Source photometry calculated by 'forcing' a PSF measurement at the exact location of the object in difference images" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
+                <h4 class="h5 text-gray-400 mb-2 ps-2">Forced{% include "includes/info_tooltip.html" with info="Source photometry calculated by 'forcing' a PSF measurement at the exact location of the object in difference images. Presented in flux-space." position="auto" link=docroot|add:"/concepts/lightcurve.html" %} and Unforced{% include "includes/info_tooltip.html" with info="Photometry collected near the location of the object during difference image processing if a source is detected above a 5𝜎 threshold (less accurate than forced photometry). Presented in magnitude-space." position="auto" link=docroot|add:"/concepts/lightcurve.html" %} Photometry</h2>
 
             </div>
 
@@ -50,23 +50,30 @@
 
 
         </div>
+        <div class="card-body pt-0">
+    {% else %}
+
+        <div class="card-body pt-0">
+            <div class="d-flex justify-content-center ms-2">
+                <h4 class="h5 text-gray-400 mb-2 ps-2">Unforced Photometry{% include "includes/info_tooltip.html" with info="Photometry collected near the location of the object during difference image processing if a source is detected above a 5𝜎 threshold (less accurate than forced photometry)" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
+
+            </div>
+
+
     {% endif %}
 
-    <div class="card-body">
-
-        <div class="d-flex justify-content-center ms-2">
-            <h4 class="h5 text-gray-400 mb-0 ps-2">Unforced Photometry{% include "includes/info_tooltip.html" with info="Photometry collected near the location of the object during difference image processing if a source is detected above a 5𝜎 threshold (less accurate than forced photometry)" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
-
-        </div>
 
 
-        <div class="w-100 ps-1 pe-1 pb-2">{{ lightcurveHtml|safe }}</div>
-        <div class="d-flex justify-content-end ms-2">
-            <small class="text-gray-500">
-                Learn how to <a href="https://plotly.com/chart-studio-help/zoom-pan-hover-controls/">interact with these plots.</a>
-            </small>
-        </div>
+
+
+
+    <div class="w-100 ps-1 pe-1 pb-2">{{ lightcurveHtml|safe }}</div>
+    <div class="d-flex justify-content-end ms-2">
+        <small class="text-gray-500">
+            Learn how to <a href="https://plotly.com/chart-studio-help/zoom-pan-hover-controls/">interact with these plots.</a>
+        </small>
     </div>
+</div>
 </div>
 
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_lightcurve.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_lightcurve.html
@@ -32,7 +32,7 @@
         </div>
         <div class="col-12 col-xl-10 pe-xl-5 ps-sm-4">
             <small class="text-gray-500">
-                Access the data from these plots in the <em>ZTF Alert Packet Data</em> table below.
+                Access the data from these plots in the <em>ZTF Alert Packet Data</em> table below. Double click on the plots to see the full lightcurve.
             </small>
         </div>
     </div>

--- a/webserver/lasair/templates/includes/widgets/widget_object_lightcurve.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_lightcurve.html
@@ -21,7 +21,7 @@
 
             <div class="col-10 col-md-11 px-xl-0">
                 <div>
-                    <h2 class="h5 text-gray-400 mb-0 ps-2">Difference Image Lightcurve{% include "includes/info_tooltip.html" with info="The difference image lightcurve reveals how the transient flux differs over time with respect to the baseline flux found in the reference image at the location of the transient" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
+                    <h2 class="h5 text-gray-400 mb-0 ps-2">Difference Image Lightcurves{% include "includes/info_tooltip.html" with info="These difference image lightcurves reveals how the transient flux differs over time with respect to the baseline flux found in the reference image at the location of the transient" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
 
                 </div>
             </div>
@@ -32,17 +32,38 @@
         </div>
         <div class="col-12 col-xl-10 pe-xl-5 ps-sm-4">
             <small class="text-gray-500">
-                Access the data from this plot in the <em>ZTF Alert Packet Data</em> table below.
+                Access the data from these plots in the <em>ZTF Alert Packet Data</em> table below.
             </small>
         </div>
     </div>
+    {% if fplightcurveHtml %}
+        <div class="card-body">
+
+            <div class="d-flex justify-content-center ms-2">
+                <h4 class="h5 text-gray-400 mb-0 ps-2">Forced Photometry{% include "includes/info_tooltip.html" with info="Source photometry calculated by 'forcing' a PSF measurement at the exact location of the object in difference images" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
+
+            </div>
+
+
+            <div class="w-100 ps-1 pe-1 pb-2">{{ fplightcurveHtml|safe }}</div>
+
+
+
+        </div>
+    {% endif %}
+
     <div class="card-body">
+
+        <div class="d-flex justify-content-center ms-2">
+            <h4 class="h5 text-gray-400 mb-0 ps-2">Unforced Photometry{% include "includes/info_tooltip.html" with info="Photometry collected near the location of the object during difference image processing if a source is detected above a 5𝜎 threshold (less accurate than forced photometry)" position="auto" link=docroot|add:"/concepts/lightcurve.html" %}</h2>
+
+        </div>
 
 
         <div class="w-100 ps-1 pe-1 pb-2">{{ lightcurveHtml|safe }}</div>
         <div class="d-flex justify-content-end ms-2">
             <small class="text-gray-500">
-                Learn how to <a href="https://plotly.com/chart-studio-help/zoom-pan-hover-controls/">interact with this plot.</a>
+                Learn how to <a href="https://plotly.com/chart-studio-help/zoom-pan-hover-controls/">interact with these plots.</a>
             </small>
         </div>
     </div>


### PR DESCRIPTION
# CHANGES

- Forced photometry plots have been added to the Lasair object pages. 

Some notes:

The ZTF forced photometry in the alert packets comes in raw counts, but it is converted to μJy on the fly when the webpages render.

From the advice given in '[A New Forced Photometry Service for the Zwicky Transient Facility](https://web.ipac.caltech.edu/staff/fmasci/ztf/zfps_userguide.pdf)', I have made these cuts to the force-photometry data:

* Removed photometric measurements set to -99999 in the output lightcurve file. This indicates that a measurement could not be computed
* Removed epochs with scisigpix > 25 DN (spatial noise-sigma per pixel)
* Removed epochs with sciinpseeing > 4 arcsec (very poor seeing)

There will be cases where the baseline flux is not zero, typically when the source producing the difference flux is found in the subtracted reference image (see panel B below from the paper). It is relatively simple to re-normalise this baseline flux to zero for an individual short-lived transient, but much harder to do so in a generic way for all transients. I have not attempted any generic correction, but I can revisit if we think this is a big enough problem.

[![](https://live.staticflickr.com/65535/53397309258_0e1d8dbed6_b.jpg)](https://live.staticflickr.com/65535/53397309258_0e1d8dbed6_b.jpg)
