### PR TITLE
Hotfix/api alerce fink

### DIFF
--- a/services/externalBrokers/fink/get_fink_annotate.py
+++ b/services/externalBrokers/fink/get_fink_annotate.py
@@ -1,4 +1,5 @@
 import os, sys
+import json
 from datetime import datetime
 import lasair
 
@@ -9,14 +10,19 @@ from src import date_nid
 sys.path.append('fink-client')
 from fink_client.consumer import AlertConsumer
 
+TESTMODE = (len(sys.argv) > 1 and sys.argv[1] == 'TEST')
+
 nid  = date_nid.nid_now()
 date = date_nid.nid_to_date(nid)
-logfile = settings.SERVICES_LOG +'/'+ date + '.log'
-logf = open(logfile, 'a')
+
+if TESTMODE:
+    logf = sys.stdout
+else:
+    logfile = settings.SERVICES_LOG +'/'+ date + '.log'
+    logf = open(logfile, 'a')
 
 # Lasair client
-L = lasair.lasair_client(settings.API_TOKEN, endpoint='https://lasair-ztf.lsst.ac.uk/api')
-#L = lasair.lasair_client(settings.API_TOKEN')
+L = lasair.lasair_client(settings.API_TOKEN, endpoint='https://' + settings.LASAIR_URL + '/api')
 topic_out = 'fink'
 
 # Fink configuration
@@ -29,11 +35,13 @@ fink_config = {
 # Instantiate a consumer
 consumer = AlertConsumer(settings.FINK_TOPICS, fink_config)
 
-#d = consumer.available_topics()
-#topics = list(d.keys())
-#topics.sort()
-#for topic in topics: 
-#    print(topic)
+if TESTMODE:
+    d = consumer.available_topics()
+    topics = list(d.keys())
+    topics.sort()
+    for topic in topics: 
+        if topic.startswith('fink'):
+            print('Found topic:', topic)
 
 nalert = {}
 n = 0
@@ -42,34 +50,19 @@ while 1:
     (topic, alert, version) = consumer.poll(maxtimeout)
     if topic is None:
         break
-    print(topic)
+    if TESTMODE:
+        print(alert['objectId'], topic)
 
-    objectId = alert['objectId']
-    classification = topic[:16]
-    classdict = {}
-
-    try: classdict['rf_snia_vs_nonia']:   float(alert['rf_snia_vs_nonia']) 
-    except: pass
-
-    try: classdict['snn_snia_vs_nonia']:  float(alert['snn_snia_vs_nonia']) 
-    except: pass
-
-    try: classdict['snn_sn_vs_all']:      float(alert['snn_sn_vs_all']) 
-    except: pass
-
-    try: classdict['rf_kn_vs_nonkn']:     float(alert['rf_kn_vs_nonkn']) 
-    except: pass
-
-    try: classdict['anomaly_score']:      float(alert['anomaly_score']) 
-    except: pass
+    if not topic in settings.FINK_TOPICS:
+        continue
 
     L.annotate(
         topic_out,
-        objectId,
-        classification,
+        alert['objectId'],
+        topic[:16],
         version='0.1',
         explanation='',
-        classdict=classdict,
+        classdict={'classification': topic},
         url='')
 
     n += 1

--- a/webserver/lasairapi/serializers.py
+++ b/webserver/lasairapi/serializers.py
@@ -98,7 +98,10 @@ class ObjectsSerializer(serializers.Serializer):
 
         result = []
         for objectId in olist:
-            result.append(objjson(objectId))
+            try:
+                result.append(objjson(objectId))
+            except Exception as e:
+                result.append({'error': str(e)})
         return result
 
 
@@ -331,9 +334,12 @@ class LightcurvesSerializer(serializers.Serializer):
 
         lightcurves = []
         for objectId in olist:
-            candidates = LF.fetch(objectId)
-            fpcandidates = FLF.fetch(objectId)
-            lightcurves.append({'objectId':objectId, 'candidates':candidates, 'forcedphot': fpcandidates})
+            try:
+                candidates = LF.fetch(objectId)
+                fpcandidates = FLF.fetch(objectId)
+                lightcurves.append({'objectId':objectId, 'candidates':candidates, 'forcedphot': fpcandidates})
+            except Exception as e:
+                lightcurves.append({'error': str(e)})
 
         LF.close()
         FLF.close()


### PR DESCRIPTION
This PR fixes three things:
- User complaint about the API, when a list of objectIds is resolved, a single bad one fails the whole list. Now there is just a "None" in the list of results, and data for the good objects.
- Fink changed their interface, this PR fixes it. We are interested in the Fink classifications:
    - fink_early_kn_candidates_ztf
    - fink_early_sn_candidates_ztf
    - fink_kn_candidates_ztf
    - fink_sn_candidates_ztf
- Alerce changed their Kafka from plain to SSH, and changed the servers. The new servers are:
    - b-1-public.publicproduction.o8ncxm.c18.kafka.us-east-1.amazonaws.com:9196
    - b-2-public.publicproduction.o8ncxm.c18.kafka.us-east-1.amazonaws.com:9196
    - b-3-public.publicproduction.o8ncxm.c18.kafka.us-east-1.amazonaws.com:9196