### PR TITLE
Special display when a column name is "url"

### DIFF
--- a/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
@@ -83,6 +83,8 @@
 
                                 {% if key == "objectId" %}
                                     <td><a href='{% url "object_detail" object.objectId %}'>{{ object.objectId }}</a></td>
+                                {% elif key == "url" %}
+				<td><a href={{ object.url }}>url</a></td>
 
                                 {% elif key in 'decmean' %}
                                     <td>{{object|keyvalue:key|floatformat:6 }}</td>

--- a/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
@@ -83,7 +83,7 @@
 
                                 {% if key == "objectId" %}
                                     <td><a href='{% url "object_detail" object.objectId %}'>{{ object.objectId }}</a></td>
-                                {% elif key == "url" %}
+				    {% elif key == "url" and object.url|length > 0 %}
 				<td><a href={{ object.url }}>url</a></td>
 
                                 {% elif key in 'decmean' %}

--- a/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
@@ -84,7 +84,7 @@
                                 {% if key == "objectId" %}
                                     <td><a href='{% url "object_detail" object.objectId %}'>{{ object.objectId }}</a></td>
 				    {% elif key == "url" and object.url|length > 0 %}
-				<td><a href={{ object.url }}>url</a></td>
+				<td><a href="{{ object.url }}">url</a></td>
 
                                 {% elif key in 'decmean' %}
                                     <td>{{object|keyvalue:key|floatformat:6 }}</td>


### PR DESCRIPTION
In tables of objects, the `objectId` column header is enhanced with a URL to the object page. This enhancement works on a column header `url`, assuming it is a link and making that link clickable. In particular, this is useful for annotations that fill in the `url` field. The relevant part of the SELECT clause is then, for example:
`BBBobjects.url as url`
An example is in [this filter](https://lasair-ztf.lsst.ac.uk/filters/1868/)