### PR TITLE
i-band shown in web and api

### DIFF
--- a/webserver/lasair/apps/object/utils.py
+++ b/webserver/lasair/apps/object/utils.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 
 filterNames  = ['g', 'r', 'i']
-filterColors = ['#859900', '#dc322f', '#2ca4db']
+filterColors = ['#31de1f', '#b52626', '#370201']
 filterFids   = [1, 2, 3]
 
 def object_difference_lightcurve(

--- a/webserver/lasair/apps/object/utils.py
+++ b/webserver/lasair/apps/object/utils.py
@@ -4,9 +4,9 @@ import plotly.graph_objects as go
 import math
 import numpy as np
 
-filterNames  = ['g', 'r']
-filterColors = ['#859900', '#dc322f']
-filterFids   = [1, 2]
+filterNames  = ['g', 'r', 'i']
+filterColors = ['#859900', '#dc322f', '#2ca4db']
+filterFids   = [1, 2, 3]
 
 def object_difference_lightcurve(
     objectData

--- a/webserver/lasair/templates/includes/scripts.html
+++ b/webserver/lasair/templates/includes/scripts.html
@@ -1,6 +1,6 @@
 <script src="{{ ASSETS_ROOT }}/js/vendor.js"></script>
 <script src="{{ ASSETS_ROOT }}/js/main.js"></script>
-<script type="text/javascript" src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js"></script>
+<script type="text/javascript" src="https://aladin.cds.unistra.fr/AladinLite/api/v3/3.5.1-beta/aladin.js"></script>
 <script type="text/javascript" src="{{ ASSETS_ROOT }}/js/lasair_js9prefs.js"></script>
 <script type="text/javascript" src="{{ ASSETS_ROOT }}/vendor/js9/js9support.min.js"></script>
 <script type="text/javascript" src="{{ ASSETS_ROOT }}/vendor/js9/js9.js"></script>

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -59,7 +59,7 @@
                         <tr>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{{ cand.mjd|floatformat:6 }}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{{ cand.utc }}{% if not cand.candid %}</font>{% endif %}</td>
-                            <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% else %}r{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
+			    <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% elif cand.fid == 1 %}r{% else %}i{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{{ cand.magpsf|floatformat:3 }} {% if cand.candid %}&plusmn; {{ cand.sigmapsf|floatformat:3 }}{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
 
 
@@ -102,7 +102,7 @@
 
                         <tr>
                             <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{{ cand.mjd|floatformat:6 }}{% if not cand.candid %}</font>{% endif %}</td>
-                            <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% else %}r{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
+			    <td>{% if not cand.candid %}<font color="gray" size=-2>{% endif %}{% if cand.fid == 1 %}g{% elif cand.fid == 2 %}r{% else %}i{% endif %}{% if not cand.candid %}</font>{% endif %}</td>
                             <td>{{ cand.magpsf|floatformat:3 }}</td>
                             <td>{% if cand.candid %}{{ cand.sigmapsf|floatformat:3 }}{% endif %}</td>
                             <td>{% if cand.candid %}{{ cand.isdiffpos|replace:"t|positive"|replace:"f|negative" }}{% else %}<font color="gray" size=-2>limit</font>{% endif %}</td>

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -264,8 +264,10 @@ def objjson(objectId, full=False):
     objectData["discMag"] = f"{detections['magpsf'].values[0]:.2f}±{detections['sigmapsf'].values[0]:.2f}"
     if detections['fid'].values[0] == 1:
         objectData["discFilter"] = "g"
-    else:
+    elif detections['fid'].values[0] == 2:
         objectData["discFilter"] = "r"
+    else:
+        objectData["discFilter"] = "i"
 
     # LATEST MAGS
     objectData["latestMjd"] = detections["mjd"].values[-1]
@@ -273,8 +275,10 @@ def objjson(objectId, full=False):
     objectData["latestMag"] = f"{detections['magpsf'].values[-1]:.2f}±{detections['sigmapsf'].values[-1]:.2f}"
     if detections['fid'].values[-1] == 1:
         objectData["latestFilter"] = "g"
+    elif detections['fid'].values[-1] == 2:
+        objectData["discFilter"] = "r"
     else:
-        objectData["latestFilter"] = "r"
+        objectData["discFilter"] = "i"
 
     # PEAK MAG
     peakMag = detections[detections['magpsf'] == detections['magpsf'].min()]
@@ -283,8 +287,10 @@ def objjson(objectId, full=False):
     objectData["peakMag"] = f"{peakMag['magpsf'].values[0]:.2f}±{peakMag['sigmapsf'].values[0]:.2f}"
     if peakMag['fid'].values[0] == 1:
         objectData["peakFilter"] = "g"
-    else:
+    elif peakMag['fid'].values[0] == 2:
         objectData["peakFilter"] = "r"
+    else:
+        objectData["peakFilter"] = "i"
 
     data = {'objectId': objectId,
             'objectData': objectData,


### PR DESCRIPTION
The i-band candidates are now shown in the webserver and delivered by the API.
See for example https://lasair-ztf.lsst.ac.uk/objects/ZTF25abbuiia/

However, the features/schema are not modified. 
See https://lasair-ztf.lsst.ac.uk/schema/
What a mess. You see why I want to dump ZTF.

These 11 attributes exist for each of `g` and `r`, but need to extended with `i` versions
`jdgmax, gmag, dmdt_g, dmdt_g_err, dmdt_g_2, mag_g02, mag_g08, mag_g28, maggmax, maggmean, maggmin`

Even more problematic is the `g-r` attributes. Should we add `g-i` and `r-i`?
`g_minus_r` and `jd_g_minus_r`